### PR TITLE
Adding Laghos to input_list.json

### DIFF
--- a/explore/input_lists.json
+++ b/explore/input_lists.json
@@ -12,6 +12,7 @@
         "zfsonlinux"
     ], 
     "repos": [
+        "ceed/Laghos",
         "dun/conman", 
         "dun/munge", 
         "hpc/dcp", 


### PR DESCRIPTION
Laghos is an LLNL-developed miniapp in the CEED project, see https://github.com/CEED/Laghos/blob/master/README.md.