### PR TITLE
Link Updates

### DIFF
--- a/about/using-github.md
+++ b/about/using-github.md
@@ -79,11 +79,11 @@ When in doubt, contact a Derivative Classifier (DC) and / or Information Managem
 There are many great "getting started" guides for GitHub, here are a few that we recommend if you're looking for more information:
 
 - [18F Handbook: GitHub](https://handbook.18f.gov/github/)
-- https://github.com/fisma-ready/github
+- [fisma-ready/github: Controls necessary for Federal use of GitHub](https://github.com/fisma-ready/github)
 
 The Federal government also provides some relevant information:
 
-- [Guidance for Agency Use of Third-Party Websites and Applications](https://www.whitehouse.gov/sites/default/files/omb/assets/memoranda_2010/m10-23.pdf)
+- [Guidance for Agency Use of Third-Party Websites and Applications](https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/memoranda_2010/m10-23.pdf)
 
 See also:
 


### PR DESCRIPTION
Fixed 404 link to point to now archived PDF document, fixes #58 
Updated fisma-ready link text that was not a clickable link.