### PR TITLE
Links to sub-pages

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -10,6 +10,13 @@ Welcome to the Lawrence Livermore National Laboratory software portal! The purpo
 
 LLNL produces software on a daily basis. Some of this software is used only internally, other components are licensed for use by external partners and collaborators, still other software is released, or even actively developed, in the open on software hosting platforms such as GitHub.com, Bitbucket.org, Sourceforge.net, and others.
 
+### Information for LLNL Developers
+
+- [GitHub Accounts and Organization](using-github)
+- [Contributing Guidelines](contributing)
+- [LLNL Licensing Guidelines](licenses)
+- [Organizations with LLNL Contributors](open-source)
+
 ### Contact
 
 If you have any questions or would like to request a private repository, please don't hesitate to contact [Ian Lee](mailto:ian@llnl.gov) or one of [the GitHub organization admins](mailto:github-admin@llnl.gov).


### PR DESCRIPTION
Manually added links to subpages of the about page. Temporary fix.

addresses #57, but not a fix.