### PR TITLE
Env Fallback

### DIFF
--- a/_explore/scripts/build_yearlist.py
+++ b/_explore/scripts/build_yearlist.py
@@ -2,11 +2,14 @@ from scraper.github import queryManager as qm
 from os import environ as env
 import os.path
 
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
 yearDict = {}
 
 # Gather all file name data
 print("Checking GitHub data file names with year stamps...")
-for file in os.listdir(env['GITHUB_DATA']):
+if not os.path.exists(ghDataDir):
+    raise FileNotFoundError("Directory path '%s' does not exist." % (ghDataDir))
+for file in os.listdir(ghDataDir):
     if file.endswith(".json"):
         nameSplit = file.split(".")
         # Must have format "somePrefix.0000.json"
@@ -25,7 +28,7 @@ for prefix in yearDict.keys():
     yearList.sort()
     yearDict[prefix] = yearList
 
-yearData = qm.DataManager("%s/YEARS.json" % env['GITHUB_DATA'], False)
+yearData = qm.DataManager("%s/YEARS.json" % ghDataDir, False)
 yearData.fileSave()
 
 print("Done!\n")

--- a/_explore/scripts/get_llnl_members.py
+++ b/_explore/scripts/get_llnl_members.py
@@ -1,7 +1,8 @@
 from scraper.github import queryManager as qm
 from os import environ as env
 
-datfilepath = "%s/labUsers.json" % env['GITHUB_DATA']
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
+datfilepath = "%s/labUsers.json" % ghDataDir
 queryPath = "../queries/org-Members.gql"
 
 # Only looking at LLNL org members

--- a/_explore/scripts/get_members_extrepos.py
+++ b/_explore/scripts/get_members_extrepos.py
@@ -1,11 +1,12 @@
 from scraper.github import queryManager as qm
 from os import environ as env
 
-datfilepath = "%s/extRepos.json" % env['GITHUB_DATA']
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
+datfilepath = "%s/extRepos.json" % ghDataDir
 queryPath = "../queries/user-Repos.gql"
 
 # Read repo info data file (to use as repo list)
-inputLists = qm.DataManager("%s/labReposInfo.json" % env['GITHUB_DATA'], True)
+inputLists = qm.DataManager("%s/labReposInfo.json" % ghDataDir, True)
 # Populate repo list
 repolist = []
 print("Getting internal repos ...")
@@ -13,7 +14,7 @@ repolist = sorted(inputLists.data["data"].keys())
 print("Repo list complete. Found %d repos." % (len(repolist)))
 
 # Read lab user data file (to use as member list)
-inputLists = qm.DataManager("%s/labUsers.json" % env['GITHUB_DATA'], True)
+inputLists = qm.DataManager("%s/labUsers.json" % ghDataDir, True)
 # Populate member list
 memberlist = []
 print("Getting LLNL members ...")

--- a/_explore/scripts/get_repos_activity.py
+++ b/_explore/scripts/get_repos_activity.py
@@ -3,11 +3,12 @@ from os import environ as env
 import re
 from datetime import datetime
 
-datfilepath = "%s/labRepos_Activity.json" % env['GITHUB_DATA']
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
+datfilepath = "%s/labRepos_Activity.json" % ghDataDir
 query_in = "/repos/OWNNAME/REPONAME/stats/commit_activity"
 
 # Read repo info data file (to use as repo list)
-inputLists = qm.DataManager("%s/labReposInfo.json" % env['GITHUB_DATA'], True)
+inputLists = qm.DataManager("%s/labReposInfo.json" % ghDataDir, True)
 # Populate repo list
 repolist = []
 print("Getting internal repos ...")

--- a/_explore/scripts/get_repos_creationhistory.py
+++ b/_explore/scripts/get_repos_creationhistory.py
@@ -2,13 +2,14 @@ from scraper.github import queryManager as qm
 from os import environ as env
 import re
 
-datfilepath = "%s/labRepos_CreationHistory.json" % env['GITHUB_DATA']
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
+datfilepath = "%s/labRepos_CreationHistory.json" % ghDataDir
 queryPath = "../queries/repo-CreationDate.gql"
 query_commits_in = "/repos/OWNNAME/REPONAME/commits?until=CREATETIME&per_page=100"
 query_commits_in2 = "/repos/OWNNAME/REPONAME/commits?per_page=100"
 
 # Read repo info data file (to use as repo list)
-inputLists = qm.DataManager("%s/labReposInfo.json" % env['GITHUB_DATA'], True)
+inputLists = qm.DataManager("%s/labReposInfo.json" % ghDataDir, True)
 # Populate repo list
 repolist = []
 print("Getting internal repos ...")

--- a/_explore/scripts/get_repos_info.py
+++ b/_explore/scripts/get_repos_info.py
@@ -1,7 +1,8 @@
 from scraper.github import queryManager as qm
 from os import environ as env
 
-datfilepath = "%s/labReposInfo.json" % env['GITHUB_DATA']
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
+datfilepath = "%s/labReposInfo.json" % ghDataDir
 queryPath = "../queries/org-Repos-Info.gql"
 queryPathInd = "../queries/repo-Info.gql"
 

--- a/_explore/scripts/get_repos_languages.py
+++ b/_explore/scripts/get_repos_languages.py
@@ -1,11 +1,12 @@
 from scraper.github import queryManager as qm
 from os import environ as env
 
-datfilepath = "%s/labRepos_Languages.json" % env['GITHUB_DATA']
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
+datfilepath = "%s/labRepos_Languages.json" % ghDataDir
 queryPath = "../queries/repo-Languages.gql"
 
 # Read repo info data file (to use as repo list)
-inputLists = qm.DataManager("%s/labReposInfo.json" % env['GITHUB_DATA'], True)
+inputLists = qm.DataManager("%s/labReposInfo.json" % ghDataDir, True)
 # Populate repo list
 repolist = []
 print("Getting internal repos ...")

--- a/_explore/scripts/get_repos_licenses.py
+++ b/_explore/scripts/get_repos_licenses.py
@@ -1,11 +1,12 @@
 from scraper.github import queryManager as qm
 from os import environ as env
 
-datfilepath = "%s/labRepos_Licenses.json" % env['GITHUB_DATA']
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
+datfilepath = "%s/labRepos_Licenses.json" % ghDataDir
 queryPath = "../queries/repo-Licenses.gql"
 
 # Read repo info data file (to use as repo list)
-inputLists = qm.DataManager("%s/labReposInfo.json" % env['GITHUB_DATA'], True)
+inputLists = qm.DataManager("%s/labReposInfo.json" % ghDataDir, True)
 # Populate repo list
 repolist = []
 print("Getting internal repos ...")

--- a/_explore/scripts/get_repos_pullsissues.py
+++ b/_explore/scripts/get_repos_pullsissues.py
@@ -1,11 +1,12 @@
 from scraper.github import queryManager as qm
 from os import environ as env
 
-datfilepath = "%s/labRepos_PullsIssues.json" % env['GITHUB_DATA']
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
+datfilepath = "%s/labRepos_PullsIssues.json" % ghDataDir
 queryPath = "../queries/repo-PullsIssues.gql"
 
 # Read repo info data file (to use as repo list)
-inputLists = qm.DataManager("%s/labReposInfo.json" % env['GITHUB_DATA'], True)
+inputLists = qm.DataManager("%s/labReposInfo.json" % ghDataDir, True)
 # Populate repo list
 repolist = []
 print("Getting internal repos ...")

--- a/_explore/scripts/get_repos_topics.py
+++ b/_explore/scripts/get_repos_topics.py
@@ -1,11 +1,12 @@
 from scraper.github import queryManager as qm
 from os import environ as env
 
-datfilepath = "%s/labRepos_Topics.json" % env['GITHUB_DATA']
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
+datfilepath = "%s/labRepos_Topics.json" % ghDataDir
 queryPath = "../queries/repo-Topics.gql"
 
 # Read repo info data file (to use as repo list)
-inputLists = qm.DataManager("%s/labReposInfo.json" % env['GITHUB_DATA'], True)
+inputLists = qm.DataManager("%s/labReposInfo.json" % ghDataDir, True)
 # Populate repo list
 repolist = []
 print("Getting internal repos ...")

--- a/_explore/scripts/get_repos_users.py
+++ b/_explore/scripts/get_repos_users.py
@@ -1,12 +1,13 @@
 from scraper.github import queryManager as qm
 from os import environ as env
 
-datfilepathExt = "%s/extUsers.json" % env['GITHUB_DATA']
-datfilepathInt = "%s/labUsers.json" % env['GITHUB_DATA']
+ghDataDir = env.get('GITHUB_DATA', '../github-data')
+datfilepathExt = "%s/extUsers.json" % ghDataDir
+datfilepathInt = "%s/labUsers.json" % ghDataDir
 queryPath = "../queries/repo-Users.gql"
 
 # Read repo info data file (to use as repo list)
-inputLists = qm.DataManager("%s/labReposInfo.json" % env['GITHUB_DATA'], True)
+inputLists = qm.DataManager("%s/labReposInfo.json" % ghDataDir, True)
 # Populate repo list
 repolist = []
 print("Getting internal repos ...")


### PR DESCRIPTION
Scripts now include a fallback path for `GITHUB_DATA` if the environment variable does not exist.

**Note** - Fallback default does not write to directory used by the website. Only the `MASTER` update will set the appropriate environment variable.