### PR TITLE
Update index.md

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -30,7 +30,7 @@ This portal abounds with examples of projects that have found a home in the open
 	- Cover story: [Ambassadors of Code](https://str.llnl.gov/2018-01/lee)
 	- [Commentary by Bruce Hendrickson](https://str.llnl.gov/2018-01/comjan18), LLNL Computation associate director
 	- Video (3:04): [Ambassadors of Code](https://youtu.be/nTxMn1NWHQU)
-- LLNL news: [Spack, A Lab-Developed 'App Store for Supercomputers,' becoming Standard-Bearer(https://www.llnl.gov/news/spack-lab-developed-app-store-supercomputers-becoming-standard-bearer)
+- LLNL news: [Spack, A Lab-Developed 'App Store for Supercomputers,' becoming Standard-Bearer](https://www.llnl.gov/news/spack-lab-developed-app-store-supercomputers-becoming-standard-bearer)
 - Code.gov blog post: [OSS Spotlight: Lawrence Livermore National Laboratory and ZFS on Linux](https://medium.com/codedotgov/oss-spotlight-lawrence-livermore-national-laboratory-and-zfs-on-linux-6596fca6e5f6)
 
 ### Information for LLNL Developers


### PR DESCRIPTION
fixed Spack link syntax - sorry, didn't notice the error until the About page was pushed to production