### PR TITLE
Filter out incomplete activity datapoints

### DIFF
--- a/js/explore/line_repoActivity.js
+++ b/js/explore/line_repoActivity.js
@@ -187,7 +187,9 @@ function draw_line_repoActivity(areaID, repoNameWOwner) {
     function reformatData(obj) {
         // Calculate combined values
         var dataTotals = {};
+        var repoCounts = {};
         var repos = repoNameWOwner == null ? Object.keys(obj['data']) : [repoNameWOwner];
+        var numReposExpected = repos.length;
         repos.forEach(function(repo) {
             if (obj['data'].hasOwnProperty(repo)) {
                 var weeklyNodes = obj['data'][repo];
@@ -196,25 +198,34 @@ function draw_line_repoActivity(areaID, repoNameWOwner) {
                     var weeklytotal = weeklyNodes[i]['total'];
                     if (!Object.keys(dataTotals).contains(weekstamp)) {
                         dataTotals[weekstamp] = 0;
+                        repoCounts[weekstamp] = 0;
                     }
                     dataTotals[weekstamp] += weeklytotal;
+                    repoCounts[weekstamp] += 1;
                 }
             } else {
                 console.log('No activity data recorded for ' + repo + ', using dummy data.');
                 // Today
                 var end = new Date();
                 dataTotals[formatTime(end)] = 0;
+                repoCounts[formatTime(end)] = 1;
                 // Tomorrow, 1 year ago
                 var start = new Date(new Date().getFullYear() - 1, new Date().getMonth(), new Date().getDate() + 1);
                 dataTotals[formatTime(start)] = 0;
+                repoCounts[formatTime(start)] = 1;
             }
         });
 
-        // Formate data for graphing
+        // Format data for graphing
         var data = [];
         var sortedTimestamps = Object.keys(dataTotals).sort();
         sortedTimestamps.forEach(function(timestamp) {
-            data.push({ date: timestamp, value: dataTotals[timestamp] });
+            var numReposFound = repoCounts[timestamp];
+            if (numReposFound == numReposExpected) {
+                data.push({ date: timestamp, value: dataTotals[timestamp] });
+            } else {
+                console.log('Repo count mismatch for activity on ' + timestamp + ': expected ' + numReposExpected + ', found ' + numReposFound);
+            }
         });
 
         return data;


### PR DESCRIPTION
GitHub's year-long repo activity start and end points can vary by a day or two between different repos. Therefore, datapoints at the beginning and end of the period only include a fraction of the repos, causing misleading dips in the activity graph.

This fix filters out any datapoints that do not include data from the full number of repos.

Before:
![ActivityBefore](https://user-images.githubusercontent.com/29315109/66966292-8f509f00-f031-11e9-877a-8ccb7ac40fa3.png)

After:
![ActivityAfter](https://user-images.githubusercontent.com/29315109/66966300-95df1680-f031-11e9-84db-841cf971ac6c.png)

Corresponding Filter Logs:
```
line_repoActivity.js:227 Repo count mismatch for activity on 2018-10-01: expected 582, found 14
line_repoActivity.js:227 Repo count mismatch for activity on 2018-10-08: expected 582, found 50
line_repoActivity.js:227 Repo count mismatch for activity on 2019-10-07: expected 582, found 568
line_repoActivity.js:227 Repo count mismatch for activity on 2019-10-14: expected 582, found 532
```

Note: The expected count is 582 even though we show 584 total repos at this time; Two repos are empty and are therefore have no activity data.