### PR TITLE
Adjustments to hyperlinked text for accessibility compliance

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,27 +14,31 @@
 
     <div id="siteNavbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav navbar-right navbar-collapse">
-          <li id="radiuss" {% if page.url == "/radiuss/" %} class="active" {% endif %}><a href="/radiuss/">RADIUSS</a></li>
+          <li id="radiuss"
+            {% if page.url == "/radiuss/" %} class="active"
+            {% endif %}><a class="navbar-normal" href="/radiuss/">RADIUSS</a></li>
         <li id="news"
             {% if page.url == "/news/" %} class="active dropdown"
             {% else %} class="dropdown"
-            {% endif %}><a href="/news/">News</a>
+            {% endif %}><a class="navbar-normal" href="/news/">News</a>
           <div class="dropdown-content">
-            <p><a href="/news/archive/">Archive</a></p>
+            <p><a class="navbar-normal" href="/news/archive/">Archive</a></p>
           </div>
         </li>
         <li id="about"
             {% if page.url == "/about/" %} class="active dropdown"
             {% else %} class="dropdown"
-            {% endif %}><a href="/about/">About</a>
+            {% endif %}><a class="navbar-normal" href="/about/">About</a>
           <div class="dropdown-content">
-            <p><a href="/about/using-github/">Using GitHub</a></p>
-            <p><a href="/about/contributing/">Contributing</a></p>
-            <p><a href="/about/licenses/">Licenses Guide</a></p>
+            <p><a class="navbar-normal" href="/about/using-github/">Using GitHub</a></p>
+            <p><a class="navbar-normal" href="/about/contributing/">Contributing</a></p>
+            <p><a class="navbar-normal" href="/about/licenses/">Licenses Guide</a></p>
           </div>
         </li>
 
-        <li id="explore" {% if page.url == "/explore/" %} class="active" {% endif %}><a href="/explore/">Explore</a></li>
+        <li id="explore"
+          {% if page.url == "/explore/" %} class="active"
+          {% endif %}><a class="navbar-normal" href="/explore/">Explore</a></li>
         <li id="github"><a href="https://github.com/llnl"><span class="fa fa-github fa-lg"></span></a></li>
         <li id="github"><a href="https://twitter.com/LLNL_OpenSource"><span class="fa fa-twitter fa-lg"></span></a></li>
       </ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,8 +3,8 @@
 
     {% include head.html %}
 
-    <body>
-
+    <body class="static-text">
+ 
         {% include header.html %}
 
         {{ content }}

--- a/about/index.md
+++ b/about/index.md
@@ -30,9 +30,9 @@ This portal abounds with examples of projects that have found a home in the open
 - [Federal OSS policy guide](https://code.gov/policy-guide/introduction)
 - 18F guest post: [The Case for Open Source Software](https://18f.gsa.gov/2018/07/12/the-case-for-open-source-software/)
 - *Science & Technology Review* coverage
-	- Cover story: [Ambassadors of Code](https://str.llnl.gov/2018-01/lee)
+	- [Cover story: Ambassadors of Code](https://str.llnl.gov/2018-01/lee)
 	- [Commentary by Bruce Hendrickson](https://str.llnl.gov/2018-01/comjan18), LLNL Computing associate director
-	- Video (3:04): [Ambassadors of Code](https://youtu.be/nTxMn1NWHQU)
+	- [Video (3:04): Ambassadors of Code](https://youtu.be/nTxMn1NWHQU)
 - LLNL news: [Spack, A Lab-Developed 'App Store for Supercomputers,' becoming Standard-Bearer](https://www.llnl.gov/news/spack-lab-developed-app-store-supercomputers-becoming-standard-bearer)
 - Code.gov blog post: [OSS Spotlight: Lawrence Livermore National Laboratory and ZFS on Linux](https://medium.com/codedotgov/oss-spotlight-lawrence-livermore-national-laboratory-and-zfs-on-linux-6596fca6e5f6)
 

--- a/about/index.md
+++ b/about/index.md
@@ -25,7 +25,7 @@ Case in point: The DOE’s [Advanced Simulation and Computing (ASC) Program](htt
 
 This portal abounds with examples of projects that have found a home in the open source community. Access is key, which is why we jumped at the chance to index our software on [Code.gov](https://code.gov). You’ll find our work in the DOE [repo list](https://code.gov/#!/browse-projects?agencies=DOE). You can also browse our projects on [GitHub](https://github.com/LLNL), [GitLab](https://gitlab.com/llnl), and [Bitbucket](https://bitbucket.org/llnl).
 
-### Learn More
+### Learn More about OSS at LLNL
 
 - [Federal OSS policy guide](https://code.gov/policy-guide/introduction)
 - 18F guest post: [The Case for Open Source Software](https://18f.gsa.gov/2018/07/12/the-case-for-open-source-software/)

--- a/css/main.css
+++ b/css/main.css
@@ -2,6 +2,12 @@
     pointer-events: none;
 }
 
+.static-text a,
+    a:visited {
+      color: #005dab;
+      text-decoration: underline;
+}
+
 /* FlexBox configuration */
 
 .flex-container {
@@ -130,9 +136,17 @@
 .navbar-header a.navbar-brand {
     color: #005dab;
     font-weight: bold;
+    text-decoration: none;
 }
+
+.navbar a.navbar-normal {
+    color: #005dab;
+    text-decoration: none;
+}
+
 .navbar {
     margin-bottom: 0;
+    text-decoration: none;
 }
 
 /* Dropdown */
@@ -143,11 +157,13 @@
     background-color: #f8f8f8;
     min-width: 160px;
     padding: 5px;
+    text-decoration: none;
 }
 
 @media (max-width: 768px) {
     .dropdown-content {
         visibility: hidden;
+        text-decoration: none;
     }
 }
 


### PR DESCRIPTION
Resolves #287. Accessibility guidelines stipulate that hyperlinks should have two styles to differentiate from regular (unlinked) text. We had one, blue color. I added underline via `static-text` CSS on default.html, which is what the informational pages and News posts use. CSS stylesheet has notes saying that no underline is used on Category nav elements, which also have color changes and other styles. So I didn't touch those; only focused on default.html layout. Also added a new class `navbar-normal` so that nav bar links are *not* underlined because they already have background and pointer changes. I am not 100% satisfied with this solution because we are not treating Catalog links the same way as on Info/static pages.