### PR TITLE
Removed table from a news post

### DIFF
--- a/_posts/2018-10-27-sc18.md
+++ b/_posts/2018-10-27-sc18.md
@@ -5,10 +5,8 @@ tags: event
 
 LLNL staff are heading to Dallas, Texas, for the 30th annual Supercomputing Conference (SC18) on November 11–16. LLNL is leading 6 tutorials and 16 workshops with topics ranging from data analytics and data compression to performance analysis and productivity. LLNL-developed open-source tools [Flux](https://github.com/flux-framework) and [Spack](https://github.com/spack/spack) are subjects of a workshop and a tutorial, respectively. We hope to see you there!
 
-| Day | Time | Type | Link|
-|----|----|----|----|
-| Sunday, November 11 | 10:55am –11:20am | Workshop | [Flux: Overcoming Scheduling Challenges for Exascale Workflows](https://sc18.supercomputing.org/presentation/?id=ws_works115&sess=sess163) |
-| Monday, November 12 | 8:30am – 5:00pm | Tutorial | [Managing HPC Software Complexity with Spack](https://sc18.supercomputing.org/presentation/?id=tut165&sess=sess252) |
-| Tuesday, November 13 | 12:15pm – 1:15pm | BOF | [Spack Community](https://sc18.supercomputing.org/presentation/?id=bof173&sess=sess428) |
+- Sunday, November 11, 10:55-11:20am, Workshop: [Flux: Overcoming Scheduling Challenges for Exascale Workflows](https://sc18.supercomputing.org/presentation/?id=ws_works115&sess=sess163)
+- Monday, November 12, 8:30am–5:00pm, Tutorial: [Managing HPC Software Complexity with Spack](https://sc18.supercomputing.org/presentation/?id=tut165&sess=sess252)
+- Tuesday, November 13, 12:15-1:15pm, BOF: [Spack Community](https://sc18.supercomputing.org/presentation/?id=bof173&sess=sess428) 
 
 [Read more](https://computing.llnl.gov/newsroom/looking-ahead-sc18) about our past experiences and tips for first-timers. A complete list of LLNL-led sessions can be found on the [LLNL Computing website](https://computing.llnl.gov/sc18-event-calendar). All times are listed in Central Standard Time.


### PR DESCRIPTION
Resolves #288. Upon review, the only issue flagged by the crawler that we can/should adjust is a table in markdown, which is not accessibility-friendly.