### PR TITLE
Corrections to 4 news posts

### DIFF
--- a/_posts/2016-01-06-mfemorigins.md
+++ b/_posts/2016-01-06-mfemorigins.md
@@ -3,4 +3,4 @@ title: "High-Order Finite Element Library Provides Scientists with Access to Cut
 tags: story
 ---
 
-[Learn more](https://computing.llnl.gov/newsroom/high-order-finite-element-library-provides-scientists-access-cutting-edge-algorithms) about the origins of [MFEM](http://mfem.org/), one of our flagship open-source projects.
+[Learn more](https://computing.llnl.gov/projects/mfem-scalable-finite-element-discretization-library) about the origins of [MFEM](http://mfem.org/), one of our flagship open-source projects.

--- a/_posts/2016-02-19-spackorigins.md
+++ b/_posts/2016-02-19-spackorigins.md
@@ -3,4 +3,4 @@ title: "A Flexible Package Manager for HPC Software"
 tags: story
 ---
 
-[Learn more](https://computing.llnl.gov/newsroom/flexible-package-manager-hpc-software) about the origins of [Spack](https://github.com/spack/spack), whose community of users and contributors continues to grow.
+[Learn more](https://computing.llnl.gov/projects/spack-hpc-package-manager) about the origins of [Spack](https://github.com/spack/spack), whose community of users and contributors continues to grow.

--- a/_posts/2019-10-26-conduit-0.5.md
+++ b/_posts/2019-10-26-conduit-0.5.md
@@ -12,4 +12,3 @@ Learn more:
 - [Release notes](https://github.com/LLNL/conduit/releases/tag/v0.5.0)
 - [GitHub repo](https://github.com/LLNL/conduit)
 - [Documentation](https://llnl-conduit.readthedocs.io/en/latest/)
-- Article: [An HPC Partnership: Harvey Mudd College and Livermore](https://computing.llnl.gov/newsroom/hpc-partnership-harvey-mudd-college-and-livermore)

--- a/_posts/2019-11-19-merlin-new.md
+++ b/_posts/2019-11-19-merlin-new.md
@@ -1,8 +1,6 @@
 ---
-title: "LLNL-Led Team Wins SC19 Best Paper Award"
-tags: story, trip-report
+title: "New Repo: Merlin"
+tags: new-repo
 ---
 
-On November 22, a panel of judges at the International Conference for High Performance Computing, Networking, Storage and Analysis (SC19) awarded a multi-institutional team led by LLNL computer scientists with the conference’s Best Paper award. The [paper](http://www.sci.utah.edu/~hbhatia/pubs/2019_SC_MUMMI.pdf), entitled “Massively Parallel Infrastructure for Adaptive Multiscale Simulations: Modeling RAS Initiation Pathway for Cancer,” describes the workflow driving a first-of-its-kind multiscale simulation on predictively modeling the dynamics of RAS proteins&mdash;a family of proteins whose mutations are linked to more than 30 percent of all human cancers&mdash;and their interactions with lipids, the organic compounds that help make up cell membranes.
-
-The team’s software, called MuMMI (Multiscale Machine-Learned Modeling Infrastructure), will soon be released as open source. Read more about the award on [LLNL news](https://www.llnl.gov/news/llnl-led-team-awarded-best-paper-sc19-modeling-cancer-causing-protein-interactions).
+[Merlin](https://github.com/LLNL/Merlin) s a tool for running machine learning based workflows. The goal of Merlin is to make it easy to build, run, and process the kinds of large scale HPC workflows needed for cognitive simulation. At its heart, Merlin is a distributed task queuing system, designed to allow complex HPC workflows to scale to large numbers of simulations. See the [documentation](https://merlin.readthedocs.io/en/latest/) for more information including configuration variables and FAQ.


### PR DESCRIPTION
computing.llnl.gov news older than 2017 was archived, which broke a few links. I also noticed that a news post was duplicating another one when it should have been something else entirely.