### PR TITLE
Expose post tags in News & Archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 _explore/LAST_MASTER_UPDATE.log
 .DS_Store
 .vscode/
+.bundle

--- a/_posts/2016-07-06-stat.md
+++ b/_posts/2016-07-06-stat.md
@@ -1,6 +1,6 @@
 ---
 title: "STAT: Discovering Supercomputers' Code Errors"
-tags: multimedia, story
+tags: multimedia story
 ---
 
 LLNL's Stack Trace Analysis Tool (STAT) reduces the number of processes requiring more in-depth analysis by organizing processes within a parallel application based on behavioral patterns. This analytic tool was designed and developed by LLNL computer scientists with collaborators at the University of Wisconsin at Madison and the University of New Mexico.  A [video](https://youtu.be/Lv8rR03ez04) explains more.

--- a/_posts/2018-03-20-str.md
+++ b/_posts/2018-03-20-str.md
@@ -1,6 +1,6 @@
 ---
 title: "LLNL Magazine Cover Story & Video: Ambassadors of Code"
-tags: multimedia, story
+tags: multimedia story
 ---
 
 The [January/February 2018 issue](https://str.llnl.gov/2018-01/lee) of Science & Technology Review features the Lab's leadership in open-source software, with cover art showing an [MFEM-generated simulation](http://mfem.org/). Contributors to the article include LLNL developers Ian Lee, Brian Behlendorf, John Fisher, Todd Gamblin, Sei Jung Kim, Tzanio Kolev, Greg Pope, and Dan Quinlan.

--- a/_posts/2018-11-12-sierra.md
+++ b/_posts/2018-11-12-sierra.md
@@ -1,6 +1,6 @@
 ---
 title: "Sierra Supercomputer Dedicated and Ranked"
-tags: story, multimedia
+tags: story multimedia
 ---
 
 LLNL recently unveiled the new 125-petaflop-capable [Sierra supercomputer](https://www.llnl.gov/news/lawrence-livermore-unveils-nnsa%E2%80%99s-sierra-world%E2%80%99s-third-fastest-supercomputer). Sierra will serve the NNSA’s three nuclear security laboratories: LLNL, Sandia National Laboratories, and Los Alamos National Laboratory, providing high-fidelity simulations in support of NNSA’s core mission of ensuring the safety, security, and effectiveness of the nation’s nuclear stockpile. Its arrival represents years of procurement, design, code development and installation, requiring the efforts of hundreds of computer scientists, developers and operations personnel working in close partnership with IBM, NVIDIA, and Mellanox.

--- a/_posts/2018-12-28-cardioid.md
+++ b/_posts/2018-12-28-cardioid.md
@@ -1,6 +1,6 @@
 ---
 title: "New Repo: Cardioid (Cardiac Simulation Toolkit)"
-tags: new-repo, multimedia
+tags: new-repo multimedia
 ---
 
 Cardioid is a cardiac multiscale simulation suite spanning from subcellular mechanisms up to simulations of organ-level clinical phenomena. The suite contains tools for simulating cardiac electrophysiology, cardiac mechanics, torso-ECGs, cardiac meshing, and fiber-generation tools. 

--- a/_posts/2019-05-08-goldstone-redhat.md
+++ b/_posts/2019-05-08-goldstone-redhat.md
@@ -1,6 +1,6 @@
 ---
 title: "Video: LLNL at the 2019 Red Hat Summit"
-tags: multimedia, trip-report
+tags: multimedia trip-report
 ---
 
 At the recent Red Hat Summit in Boston, LLNL's Robin Goldstone discussed open-source technologies and the Sierra supercomputer. Goldstone, an HPC solutions architect, said "open source makes perfect sense" for scalability and performance in an HPC center like LLNL's. She stated, "We have all that visibility and that software. If it doesn't work for our needs, we can make it work for our needs. And then we can give it back to the community because even though people aren't doing things at the scale that we are today, a lot of the things that we're doing really do trickle down and be used by a lot of other people." A transcript of her interview is included with the [video](https://video.cube365.net/c/914449), which runs 15:28.

--- a/_posts/2019-06-12-cardioid-article.md
+++ b/_posts/2019-06-12-cardioid-article.md
@@ -1,6 +1,6 @@
 ---
 title: "Redesign of Cardioid's Heartbeat Simulation Brings Code One Step Closer to Clinical Use"
-tags: multimedia, story
+tags: multimedia story
 ---
 
 LLNL researchers have successfully optimized a code that models the human heartbeat for next-generation, GPU-based supercomputers, with an eye on developing it for virtual drug screening and modeling heart activity in clinical settings. Cardioid, a suite merging mathematical solvers for electrophysiology, fiber-generation, cardiac mechanics, torso-electrocardiograms (ECGs) and cardiac meshing tools, simulates the electrical current running through the heart tissue, triggering cells to contract like cascading dominoes and causing the heart to beat. It was originally developed by LLNL and IBM for Sequoia, at one time the world’s fastest supercomputer, and was a finalist for the 2012 Gordon Bell Prize, supercomputing’s top honor.

--- a/_posts/2019-08-22-juliacon.md
+++ b/_posts/2019-08-22-juliacon.md
@@ -1,6 +1,6 @@
 ---
 title: "JuliaCon Recap and Videos"
-tags: multimedia, trip-report
+tags: multimedia trip-report
 ---
 
 LLNL’s [Seth Bromberger](https://github.com/orgs/LLNL/people/sbromberger) attended [JuliaCon 2019](https://juliacon.org) on July 22–25 in Baltimore, Maryland. He gave a talk on July 24 to a full house: “Using Julia in Secure Environments” ([abstract](https://pretalx.com/juliacon2019/talk/JANJFM/), [YouTube video](https://youtu.be/o8UBszD_zn4)). The focus of the presentation was engaging the community in thinking about transitive package dependencies and the security of the source code supply chain.

--- a/news/archive.md
+++ b/news/archive.md
@@ -6,7 +6,7 @@ permalink: /news/archive/
 {% assign postsByYear = site.posts | group_by_exp:"page", "page.date | date: '%Y'" %}
 
 <div>
-    {% for year in postsByYear %}
+   {% for year in postsByYear %}
         <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#{{year.name}}" aria-expanded="true" aria-controls="{{year.name}}"> {{year.name}} <i class= "fa fa-caret-down"></i></button>
 
         <div>
@@ -15,10 +15,11 @@ permalink: /news/archive/
                     <article class="news">
                         <h3>
                             {{post.title}}
-                            <small class="pull-right">{{ post.date | date: '%B %d, %Y' }}</small>
+                            <small class="pull-right">{{ post.date | date: '%B %d, %Y' }} {% for tag in post.tags %} ({{ tag }}) {% endfor %}</small>
                         </h3>
 
                         {{ post.content }}
+                        
                     </article>
                 {% endfor %}
             </div>

--- a/news/index.md
+++ b/news/index.md
@@ -9,12 +9,12 @@ permalink: /news/
   <article class="news">
     <h3>
       {{ page.title }}
-      <small class="pull-right">{{ page.date | date: '%B %d, %Y' }}</small>
+      <small class="pull-right">{{ page.date | date: '%B %d, %Y' }} {% for tag in page.tags %} ({{ tag }}) {% endfor %}</small>
     </h3>
 
     {{ page.content }}
 
-    </article>
+  </article>
   {% endfor %}
   
    <br />


### PR DESCRIPTION
Partially fulfills issue #252. I am working on filtering News by tag so we won't need a separate Events page (issue #97) and the like. This branch is many months old, so I still need to remove commas from tags on newer posts.

Example of post with >1 tag exposed: May 08, 2019 (multimedia) (trip-report)


