### PR TITLE
Tag cleanup on News posts

### DIFF
--- a/_posts/2016-02-05-glvis-3.1.md
+++ b/_posts/2016-02-05-glvis-3.1.md
@@ -1,6 +1,6 @@
 ---
 title: "GLVis 3.1 Released"
-tags: new-release
+tags: release
 ---
 
 [Version 3.1](https://glvis.org/download/) of GLVis, a lightweight OpenGL tool for accurate and flexible finite element visualization, is now available.

--- a/_posts/2016-02-16-mfem-3.1.md
+++ b/_posts/2016-02-16-mfem-3.1.md
@@ -1,6 +1,6 @@
 ---
 title: "MFEM 3.1 Released"
-tags: new-release
+tags: release
 ---
 
 [Version 3.1](https://mfem.org/download/) of MFEM, a lightweight, general, scalable C++ library for finite element methods, is now available.

--- a/_posts/2016-03-09-visit-2.10.1.md
+++ b/_posts/2016-03-09-visit-2.10.1.md
@@ -1,6 +1,6 @@
 ---
 title: "VisIt 2.10.1 Released"
-tags: new-release
+tags: release
 ---
 
 Source code and prebuilt executables are available on the [VisIt web site](https://visit.llnl.gov/).

--- a/_posts/2016-03-22-zfsonlinux-0.6.5.6.md
+++ b/_posts/2016-03-22-zfsonlinux-0.6.5.6.md
@@ -1,6 +1,6 @@
 ---
 title: "OpenZFS on Linux 0.6.5.6"
-tags: new-release
+tags: release
 ---
 
 Version 0.6.5.6 of OpenZFS on Linux, the native Linux kernel port of the ZFS filesystem, is now available at: [http://zfsonlinux.org](http://zfsonlinux.org)

--- a/_posts/2016-06-09-hypre-2.11.1.md
+++ b/_posts/2016-06-09-hypre-2.11.1.md
@@ -1,6 +1,6 @@
 ---
 title: "Hypre 2.11.1"
-tags: new-release
+tags: release
 ---
 
 Congratulations to the Hypre team, that today released [version 2.11.1](https://github.com/LLNL/hypre/releases/tag/v2.11.1), now available from their GitHub project page.

--- a/_posts/2016-06-30-glvis-3.2.md
+++ b/_posts/2016-06-30-glvis-3.2.md
@@ -1,6 +1,6 @@
 ---
 title: "GLVis 3.2 Released"
-tags: new-release
+tags: release
 ---
 
 [Version 3.2](https://github.com/glvis/glvis/blob/v3.2/CHANGELOG) of [GLVis](https://glvis.org/), a lightweight OpenGL tool for accurate and flexible finite element visualization, is now available.

--- a/_posts/2016-06-30-mfem-3.2.md
+++ b/_posts/2016-06-30-mfem-3.2.md
@@ -1,6 +1,6 @@
 ---
 title: "MFEM 3.2 Released"
-tags: new-release
+tags: release
 ---
 
 [Version 3.2](https://mfem.org/download/) of MFEM, a lightweight, general, scalable C++ library for finite element methods, is now available.

--- a/_posts/2016-07-21-visit-2.10.3.md
+++ b/_posts/2016-07-21-visit-2.10.3.md
@@ -1,6 +1,6 @@
 ---
 title: "VisIt 2.10.3 Released"
-tags: new-release
+tags: release
 ---
 
 Version 2.10.3 of VisIt, a cross platform Open Source, interactive, scalable, visualization, animation and analysis tool is now available at: [visit.llnl.gov](https://visit.llnl.gov/)

--- a/_posts/2016-11-03-conduit-0.2.0.md
+++ b/_posts/2016-11-03-conduit-0.2.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Conduit 0.2.0 Released"
-tags: new-release
+tags: release
 ---
 
 Conduit [version 0.2.0](https://github.com/LLNL/conduit/releases/tag/v0.2.0) is now available. Conduit provides APIs focused on simplifying data exchange in HPC simulations. It provides an intuitive model for describing hierarchical scientific data in C++, C, Fortran, and Python and is used for data coupling between packages in-core, serialization, and I/O tasks.

--- a/_posts/2016-11-10-visit-2.12.0.md
+++ b/_posts/2016-11-10-visit-2.12.0.md
@@ -1,6 +1,6 @@
 ---
 title: "VisIt 2.12.0 Released"
-tags: new-release
+tags: release
 ---
 Version 2.12.0 of VisIt is now available at: [visit.llnl.gov](https://visit.llnl.gov/)
 

--- a/_posts/2017-01-06-conduit-0.2.1.md
+++ b/_posts/2017-01-06-conduit-0.2.1.md
@@ -1,6 +1,6 @@
 ---
 title: "Conduit 0.2.1 Released"
-tags: new-release
+tags: release
 ---
 
 Conduit provides APIs focused on simplifying data exchange in HPC simulations. It provides an intuitive model for describing hierarchical scientific data in C++, C, Fortran, and Python and is used for data coupling between packages in-core, serialization, and I/O tasks.

--- a/_posts/2017-01-10-strawman-0.1.0.md
+++ b/_posts/2017-01-10-strawman-0.1.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Strawman 0.1.0 Released"
-tags: new-release
+tags: release
 ---
 
 [Strawman](https://github.com/llnl/strawman) is an open source many-core capable lightweight in situ visualization and analysis infrastructure for multi-physics HPC simulations.

--- a/_posts/2017-01-28-mfem-3.3.md
+++ b/_posts/2017-01-28-mfem-3.3.md
@@ -1,6 +1,6 @@
 ---
 title: "MFEM 3.3 Released"
-tags: new-release
+tags: release
 ---
 
 [Version 3.3](https://mfem.org/download/) of MFEM, a lightweight, general, scalable C++ library for finite element methods, is now available.

--- a/_posts/2017-06-30-visit-2.12.3.md
+++ b/_posts/2017-06-30-visit-2.12.3.md
@@ -1,6 +1,6 @@
 ---
 title: "VisIt 2.12.3 Released"
-tags: new-release
+tags: release
 ---
 Version 2.12.3 of VisIt is now available at: [visit.llnl.gov](https://visit.llnl.gov/)
 

--- a/_posts/2017-11-10-mfem-3.3.2.md
+++ b/_posts/2017-11-10-mfem-3.3.2.md
@@ -1,6 +1,6 @@
 ---
 title: "MFEM 3.3.2 Released"
-tags: new-release
+tags: release
 ---
 
 [Version 3.3.2](https://mfem.org/download/) of MFEM, a lightweight, general, scalable C++ library for finite element methods, is now available.

--- a/_posts/2018-02-26-conduit-0.3.1.md
+++ b/_posts/2018-02-26-conduit-0.3.1.md
@@ -1,6 +1,6 @@
 ---
 title: "Conduit 0.3.1 Released"
-tags: new-release
+tags: release
 ---
 
 Conduit [version 0.3.1](https://github.com/LLNL/conduit/releases/tag/v0.3.1) ([Read the Docs](https://llnl-conduit.readthedocs.io/en/v0.3.1/)) is now available. Conduit provides APIs focused on simplifying data exchange in HPC simulations. It provides an intuitive model for describing hierarchical scientific data in C++, C, Fortran, and Python and is used for data coupling between packages in-core, serialization, and I/O tasks.

--- a/_posts/2018-05-29-mfem-3.4.md
+++ b/_posts/2018-05-29-mfem-3.4.md
@@ -1,6 +1,6 @@
 ---
 title: "MFEM 3.4 Released"
-tags: new-release
+tags: release
 ---
 
 [Version 3.4](https://mfem.org/download/) of MFEM, a lightweight, general, scalable C++ library for finite element methods, is now available.

--- a/_posts/2018-07-31-sundials.md
+++ b/_posts/2018-07-31-sundials.md
@@ -1,6 +1,6 @@
 ---
 title: "SUNDIALS 3.1.2 Released"
-tags: new-release
+tags: release
 ---
 
 SUNDIALs consists of six solvers and is implemented with the goal of providing robust time integrators and nonlinear solvers that can easily be incorporated into existing simulation codes. We have created a robust [portal](https://computing.llnl.gov/projects/sundials) for users that includes documentation, usage notes, related publication, support information, and [downloads](https://computing.llnl.gov/projects/sundials/sundials-software). Detailed [release history](https://computing.llnl.gov/projects/sundials/release-history) is available. Users can also fork the code on [GitHub](https://github.com/LLNL/sundials).

--- a/_posts/2018-10-01-sundials-3.2.md
+++ b/_posts/2018-10-01-sundials-3.2.md
@@ -1,6 +1,6 @@
 ---
 title: "SUNDIALS 3.2 Released"
-tags: new-release
+tags: release
 ---
 
 This latest release includes a constraint handling in CVODE/CVODES, hybrid MPI/CUDA support, and a number of bug fixes and build system updates. In addition, the SUNDIALS team has put out a development release, v4.0.0-dev.2, which  includes encapsulated nonlinear solvers for all time integrators, streamlining of the linear solver interfaces in CVODE, ARKode, IDA, and KINSOL, and a reorganization of ARKode to allow for more time stepping options. The development release is another step toward a larger major release scheduled for the end of 2018. The full 4.0.0 release will also include the streamlined linear solver interfaces for CVODES and IDAS as well as a two-rate explicit/explicit integrator.  

--- a/_posts/2018-10-25-umpire-0.2.4.md
+++ b/_posts/2018-10-25-umpire-0.2.4.md
@@ -1,6 +1,6 @@
 ---
 title: "Umpire 0.2.4 Released"
-tags: new-release
+tags: release
 ---
 
 [Umpire](https://github.com/LLNL/Umpire) is a resource management library that allows the discovery, provision, and management of memory on next-generation architectures. It uses CMake and [BLT](https://github.com/LLNL/blt) to handle builds. New features in this version include:

--- a/_posts/2018-11-01-ghuniverse.md
+++ b/_posts/2018-11-01-ghuniverse.md
@@ -1,6 +1,6 @@
 ---
 title: "Good Times at GitHub Universe"
-tags: trip-report
+tags: event-report
 ---
 
 LLNL open-source champions [Laura Weber](https://github.com/LRWeber), [Ian Lee](https://github.com/IanLee1521), and [David Beckingsale](https://github.com/davidbeckingsale) attended the [2018 GitHub Universe](https://githubuniverse.com/2018/program/) conference in San Francisco. Billed as “a conference for the builders, planners, and leaders defining the future of software”, the team enjoyed hearing about upcoming GitHub enhancements and being able to network with GitHub Federal employees and other GitHub users.

--- a/_posts/2018-11-20-sc18recap.md
+++ b/_posts/2018-11-20-sc18recap.md
@@ -1,6 +1,6 @@
 ---
 title: "DOE Machines Dominate Record-Breaking SC18"
-tags: trip-report
+tags: event-report
 ---
 
 Supercomputing '18 (SC18), held Nov. 11–16 in Dallas, broke records for attendees and exhibitors and saw LLNL once again make its presence felt on the world’s biggest HPC stage. For the first time in five years, the U.S. captured the top two spots on the TOP500 List of the world’s fastest supercomputers: Summit at ORNL and [Sierra](https://hpc.llnl.gov/hardware/platforms/sierra) at LLNL.

--- a/_posts/2018-12-01-vcdat-1.0.md
+++ b/_posts/2018-12-01-vcdat-1.0.md
@@ -1,6 +1,6 @@
 ---
 title: "vCDAT 1.0 Released"
-tags: new-release
+tags: release
 ---
 
 LLNL's Community Data Analysis Tools (CDAT) provide a synergistic approach to climate modeling, allowing researchers to advance scientific visualization of large-scale climate data sets.

--- a/_posts/2018-12-06-esgfinst-3.0.md
+++ b/_posts/2018-12-06-esgfinst-3.0.md
@@ -1,6 +1,6 @@
 ---
 title: "ESGF Installer 3.0 Beta Released"
-tags: new-release
+tags: release
 ---
 
 The long-awaited Earth System Grid Federation (ESGF) installer software [v3.0 beta release](https://github.com/ESGF/esgf-installer/releases/tag/v3.0b1) is here!

--- a/_posts/2018-12-20-sundials-4.0.md
+++ b/_posts/2018-12-20-sundials-4.0.md
@@ -1,6 +1,6 @@
 ---
 title: "SUNDIALS 4.0 Released"
-tags: new-release
+tags: release
 ---
 
 This release includes unified linear solver interfaces in all SUNDIALS packages, encapsulated nonlinear solvers in all SUNDIALS integrators, a reorganization of ARKode to allow for the development of new integration methods, a new ARKode stepper for two-rate explicit/explicit multirate infinitesimal step methods, Fortran 2003 interfaces to CVODE and several SUNDIALS modules, an OpenMP 4.5+ NVECTOR, managed memory capabilities for the CUDA NVECTOR, and other improvements.  

--- a/_posts/2018-12-28-cardioid.md
+++ b/_posts/2018-12-28-cardioid.md
@@ -1,6 +1,6 @@
 ---
 title: "New Repo: Cardioid (Cardiac Simulation Toolkit)"
-tags: new-repo multimedia
+tags: multimedia new-repo
 ---
 
 Cardioid is a cardiac multiscale simulation suite spanning from subcellular mechanisms up to simulations of organ-level clinical phenomena. The suite contains tools for simulating cardiac electrophysiology, cardiac mechanics, torso-ECGs, cardiac meshing, and fiber-generation tools. 

--- a/_posts/2019-01-10-raja-0.7.0.md
+++ b/_posts/2019-01-10-raja-0.7.0.md
@@ -1,6 +1,6 @@
 ---
 title: "RAJA 0.7.0 Released"
-tags: new-release
+tags: release
 ---
 
 RAJA is a software abstraction that systematically encapsulates platform-specific code to enable applications to be portable across diverse hardware architectures without major source code disruption. The v0.7.0 release contains several major changes, new features, a variety of bug fixes, and expanded user documentation and accompanying example codes. Major changes include:

--- a/_posts/2019-01-23-sundials-4.0.2.md
+++ b/_posts/2019-01-23-sundials-4.0.2.md
@@ -1,6 +1,6 @@
 ---
 title: "SUNDIALS 4.0.2 Released"
-tags: new-release
+tags: release
 ---
 
 This release is a patch with many changes, including (but not limited to):

--- a/_posts/2019-01-25-cct-1.0.4.md
+++ b/_posts/2019-01-25-cct-1.0.4.md
@@ -1,6 +1,6 @@
 ---
 title: "CCT 1.0.4 Released"
-tags: new-release
+tags: release
 ---
 
 The Coda Calibration Tool (CCT) calculates reliable moment magnitudes for small- to moderate-sized seismic events. The [v1.0.4 release](https://github.com/LLNL/coda-calibration-tool/releases/tag/1.0.4) includes several performance and stability improvements along with a few new features:

--- a/_posts/2019-01-30-aluminum-0.2.md
+++ b/_posts/2019-01-30-aluminum-0.2.md
@@ -1,6 +1,6 @@
 ---
 title: "Aluminum 0.2 Released"
-tags: new-release
+tags: release
 ---
 
 First released in September 2018, Aluminum provides a generic interface to high-performance communication libraries with a focus on allreduce algorithms. Blocking and non-blocking algorithms and GPU-aware algorithms are supported. Aluminum also contains custom implementations of select algorithms to optimize for certain situations.

--- a/_posts/2019-02-01-hiop-0.2.md
+++ b/_posts/2019-02-01-hiop-0.2.md
@@ -1,6 +1,6 @@
 ---
 title: "HiOp 0.2 Released"
-tags: new-release
+tags: release
 ---
 
 HiOp is an optimization solver for solving certain mathematical optimization problems expressed as nonlinear programming problems. This lightweight HPC solver leverages application's existing data parallelism to parallelize the optimization iterations by using specialized linear algebra kernels.

--- a/_posts/2019-02-11-lbann-0.9.md
+++ b/_posts/2019-02-11-lbann-0.9.md
@@ -1,6 +1,6 @@
 ---
 title: "LBANN 0.9 Released"
-tags: new-release
+tags: release
 ---
 
 The Livermore Big Artificial Neural Network toolkit (LBANN) is an open-source, HPC-centric, deep learning training framework that is optimized to compose multiple levels of parallelism. 

--- a/_posts/2019-02-12-ccloud-0.9.7.md
+++ b/_posts/2019-02-12-ccloud-0.9.7.md
@@ -1,6 +1,6 @@
 ---
 title: "Charliecloud 0.9.7 Released"
-tags: new-release
+tags: release
 ---
 
 Charliecloud provides user-defined software stacks (UDSS) for HPC centers. It uses Linux user namespaces to run containers with no privileged operations or daemons and minimal configuration changes on center resources.

--- a/_posts/2019-02-12-esgfrecap.md
+++ b/_posts/2019-02-12-esgfrecap.md
@@ -1,6 +1,6 @@
 ---
 title: "ESGF Conference Caps a Productive Year"
-tags: trip-report
+tags: event-report
 ---
 
 Held in Washington, DC, the Earth System Grid Federation’s (ESGF) 8th annual face-to-face conference was a lively, fruitful affair. The event packed 40 presentations, several plenary sessions, a poster session, guest speakers, an awards ceremony, and an executive committee meeting into the week. 

--- a/_posts/2019-02-13-sundials-4.1.0.md
+++ b/_posts/2019-02-13-sundials-4.1.0.md
@@ -1,6 +1,6 @@
 ---
 title: "SUNDIALS 4.1.0 Released"
-tags: new-release
+tags: release
 ---
 
 In this release:

--- a/_posts/2019-02-25-umpire-0.3.2.md
+++ b/_posts/2019-02-25-umpire-0.3.2.md
@@ -1,6 +1,6 @@
 ---
 title: "Umpire 0.3.2 Released"
-tags: new-release
+tags: release
 ---
 
 Umpire is a resource management library that allows the discovery, provision, and management of memory on next-generation architectures. (Please download the umpire-0.3.2.tar.gz file, rather than the automatically generated files. These do not include all the necessary submodule code.)

--- a/_posts/2019-02-25-unify-0.2.0.md
+++ b/_posts/2019-02-25-unify-0.2.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Unify 0.2.0 Released"
-tags: new-release
+tags: release
 ---
 
 Unify is a suite of specialized, flexible file systems&mdash;this one is for checkpoint/restart workloads&mdash;that can be included in a user’s job allocations. This v0.2.0 release builds on the repo's initial release from January.

--- a/_posts/2019-03-01-conduit-0.4.md
+++ b/_posts/2019-03-01-conduit-0.4.md
@@ -1,6 +1,6 @@
 ---
 title: "Conduit 0.4 Released"
-tags: new-release
+tags: release
 ---
 
 Conduit provides an intuitive model for describing hierarchical scientific data in C++, C, Fortran, and Python. It is used for data coupling between packages in-core, serialization, and I/O tasks. The Core API provides a flexible way to describe and access hierarchical data. v0.4 includes several new functions, new Blueprint protocols, and enhanced Relay support.

--- a/_posts/2019-03-02-magpie-2.1.md
+++ b/_posts/2019-03-02-magpie-2.1.md
@@ -1,6 +1,6 @@
 ---
 title: "Magpie 2.1 Released"
-tags: new-release
+tags: release
 ---
 
 Magpie allows Hadoop and similar data analytics frameworks to run on LLNL’s HPC systems. Magpie instantiates the framework within the context of a batch job -- rather than on a persistent, dedicated cluster -- and by reading and writing from the Lustre parallel HPC file system instead of local disk drives.

--- a/_posts/2019-03-04-caliper-2.0.md
+++ b/_posts/2019-03-04-caliper-2.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Caliper 2.0 Released"
-tags: new-release
+tags: release
 ---
 
 Caliper is a program instrumentation and performance measurement framework. It is designed as a performance analysis toolbox in a library, allowing one to bake performance analysis capabilities directly into applications and activate them at runtime. Caliper is primarily aimed at HPC applications but works for any C/C++/Fortran program on Unix/Linux.

--- a/_posts/2019-03-06-cct-1.0.4.M2.1.md
+++ b/_posts/2019-03-06-cct-1.0.4.M2.1.md
@@ -1,6 +1,6 @@
 ---
 title: "CCT 1.0.4-M2.1 Released"
-tags: new-release
+tags: release
 ---
 
 The Coda Calibration Tool (CCT) calculates reliable moment magnitudes for small- to moderate-sized seismic events. After the January 25 release, you spoke and we listened! This is a minor bugfix and feature update release based on community feedback. Changes include:

--- a/_posts/2019-03-11-ccloud-0.9.8.md
+++ b/_posts/2019-03-11-ccloud-0.9.8.md
@@ -1,6 +1,6 @@
 ---
 title: "Charliecloud 0.9.8 Released"
-tags: new-release
+tags: release
 ---
 
 Charliecloud provides user-defined software stacks (UDSS) for HPC centers. It uses Linux user namespaces to run containers with no privileged operations or daemons and minimal configuration changes on center resources.

--- a/_posts/2019-03-15-ossummit.md
+++ b/_posts/2019-03-15-ossummit.md
@@ -1,6 +1,6 @@
 ---
 title: "The Linux Foundation's Open Source Leadership Summit"
-tags: trip-report
+tags: event-report
 ---
 
 The Linux Foundation's Open Source Leadership Summit occurred in Half Moon Bay, California, on Thursday, March 14. LLNL's [Todd Gamblin](https://github.com/tgamblin) presented "Open Source in the Exascale Computing Project: Building a Software Ecosystem for Science." Check out the [conference schedule](https://events.linuxfoundation.org/events/open-source-leadership-summit-2019/program/schedule/).

--- a/_posts/2019-03-28-raja-0.8.0.md
+++ b/_posts/2019-03-28-raja-0.8.0.md
@@ -1,6 +1,6 @@
 ---
 title: "RAJA 0.8.0 & RAJAPerf 0.5.0 Released"
-tags: new-release
+tags: release
 ---
 
 RAJA is a software abstraction that systematically encapsulates platform-specific code to enable applications to be portable across diverse hardware architectures without major source code disruption. The RAJA performance suite (RAJAPerf) is designed to explore performance of loop-based computational kernels of the sort found in HPC applications.

--- a/_posts/2019-03-28-sundials-5.0.0.md
+++ b/_posts/2019-03-28-sundials-5.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: "SUNDIALS 5.0.0-dev.0 Released"
-tags: new-release
+tags: release
 ---
 
 SUNDIALS is a SUite of Nonlinear and DIfferential/ALgebraic equation Solvers. In this release, an additional N_Vector implementation, NVECTOR_MANYVECTOR, was created to support flexible partitioning of solution data among different processing elements (e.g., CPU + GPU) or for multi-physics problems that couple distinct MPI-based simulations together. Eleven new optional vector operations have also been added to the N_Vector API to support the new NVECTOR_MANYVECTOR implementation.

--- a/_posts/2019-03-29-scr-2.0.md
+++ b/_posts/2019-03-29-scr-2.0.md
@@ -1,6 +1,6 @@
 ---
 title: "SCR 2.0 Released"
-tags: new-release
+tags: release
 ---
 
 The Scalable Checkpoint/Restart (SCR) library enables MPI applications to utilize distributed storage on Linux clusters to attain high file I/O bandwidth for checkpointing, restarting, and writing large datasets. The 2.0 release marks a milestone in SCR's long history of bringing dependable, scalable, file set management to multiple HPC platforms.

--- a/_posts/2019-04-01-libceed-0.4.md
+++ b/_posts/2019-04-01-libceed-0.4.md
@@ -1,6 +1,6 @@
 ---
 title: "libCEED 0.4 Released"
-tags: new-release
+tags: release
 ---
 
 libCEED is a low-level API library for the efficient high-order discretization methods developed by the Exascale Computing Project's co-design [Center for Efficient Exascale Discretizations](https://ceed.exascaleproject.org/), also known as CEED. 

--- a/_posts/2019-04-11-umpire-0.3.3.md
+++ b/_posts/2019-04-11-umpire-0.3.3.md
@@ -1,6 +1,6 @@
 ---
 title: "Umpire 0.3.3 Released"
-tags: new-release
+tags: release
 ---
 
 Umpire is a resource management library that allows the discovery, provision, and management of memory on next-generation architectures.

--- a/_posts/2019-04-12-rajaperf-0.5.1.md
+++ b/_posts/2019-04-12-rajaperf-0.5.1.md
@@ -1,6 +1,6 @@
 ---
 title: "RAJAPerf 0.5.1 Released"
-tags: new-release
+tags: release
 ---
 
 The RAJA performance suite (RAJAPerf) is designed to explore performance of loop-based computational kernels found in HPC applications. It is used to assess, monitor, and compare runtime performance of kernels implemented using RAJA and variants implemented using standard or vendor-supported parallel programming models directly.

--- a/_posts/2019-04-13-ccloud-0.9.9.md
+++ b/_posts/2019-04-13-ccloud-0.9.9.md
@@ -1,6 +1,6 @@
 ---
 title: "Charliecloud 0.9.9 Released"
-tags: new-release
+tags: release
 ---
 
 Charliecloud provides user-defined software stacks (UDSS) for HPC centers. It uses Linux user namespaces to run containers with no privileged operations or daemons and minimal configuration changes on center resources.

--- a/_posts/2019-04-15-calipervihps.md
+++ b/_posts/2019-04-15-calipervihps.md
@@ -1,6 +1,6 @@
 ---
 title: "Caliper Library Highlighted at 31st VI-HPS Tuning Workshop"
-tags: trip-report
+tags: event-report
 ---
 
 The [Virtual Institute – High Productivity Supercomputing (VI-HPS)](https://www.vi-hps.org/) conducts a long-running series of tuning workshops, where participants can learn about programming tools developed by the institute partners. Morning sessions consist of tool presentations and hands-on exercises. In the afternoon, users can apply the tools to their own codes with the help of the instructors. Whilst most of the workshops take place in Europe, the 31st tuning workshop was held at the University of Tennessee, Knoxville (UTK), on April 9–12, 2019.

--- a/_posts/2019-04-17-memsurfer-1.0.md
+++ b/_posts/2019-04-17-memsurfer-1.0.md
@@ -1,6 +1,6 @@
 ---
 title: "MemSurfer 1.0 Released"
-tags: new-release
+tags: release
 ---
 
 This is MemSurfer's initial release. MemSurfer is an efficient and versatile tool to compute and analyze membrane surfaces found in a wide variety of large-scale molecular simulations. MemSurfer works independent of the type of simulation, directly on the 3D point coordinates, and can handle a variety of membranes as well as atomic simulations. It provides many in-built analysis tasks, such as computing the membrane curvature, density and normals of lipids, and area per lipid.

--- a/_posts/2019-04-23-spackriken.md
+++ b/_posts/2019-04-23-spackriken.md
@@ -1,6 +1,6 @@
 ---
 title: "Spack Team Visits RIKEN"
-tags: trip-report
+tags: event-report
 ---
 
 Spack's [first tutorial](https://twitter.com/tgamblin/status/1120581579691053056) in Japan took place on April 23, 2019. With more than 40 participants, the onsite tutorial at RIKEN's Kobe research center was the latest international event for the Spack team and collaborators. Read more about Spack's [European tour](https://www.llnl.gov/news/spack-lab-developed-app-store-supercomputers-becoming-standard-bearer) of HPC facilities. Everything you need to get started with Spack is available on the [website](https://spack.io/).

--- a/_posts/2019-04-24-pnmpi-1.8.1.md
+++ b/_posts/2019-04-24-pnmpi-1.8.1.md
@@ -1,6 +1,6 @@
 ---
 title: "PnMPI 1.8.1 Released"
-tags: new-release
+tags: release
 ---
 
 PnMPI is a dynamic MPI tool infrastructure that builds on top of the standardized PMPI interface. With it you can run multiple PMPI tools concurrently, activate PMPI tools without relinking, multiplex toolsets during a single run, and write cooperative PMPI tools.

--- a/_posts/2019-04-25-magpie-2.2.md
+++ b/_posts/2019-04-25-magpie-2.2.md
@@ -1,6 +1,6 @@
 ---
 title: "Magpie 2.2 Released"
-tags: new-release
+tags: release
 ---
 
 Magpie contains a number of scripts for running big data software in HPC environments. It currently supports running over the parallel file system Lustre and running over any generic network filesystem. There is scheduler/resource manager support for Slurm, Moab, Torque, and LSF.

--- a/_posts/2019-04-29-msrsafe-1.3.0.md
+++ b/_posts/2019-04-29-msrsafe-1.3.0.md
@@ -1,6 +1,6 @@
 ---
 title: "MSR-SAFE 1.3.0 Released"
-tags: new-release
+tags: release
 ---
 
 MSR-SAFE allows safer access to model-specific registers. v1.3.0 includes updates to the spank plugin, `msrsave` and `msrrestore` functions, and command line parameters. The release also adds an initial Travis CI yaml configuration file to test against multiple OS.

--- a/_posts/2019-05-01-visit-3.0.md
+++ b/_posts/2019-05-01-visit-3.0.md
@@ -1,6 +1,6 @@
 ---
 title: "VisIt 3.0 Released"
-tags: new-release
+tags: release
 ---
 
 This is a huge release for LLNL's VisIt visualization tool. The many new features include:

--- a/_posts/2019-05-05-zfp-0.5.5.md
+++ b/_posts/2019-05-05-zfp-0.5.5.md
@@ -1,6 +1,6 @@
 ---
 title: "zfp 0.5.5 Released"
-tags: new-release
+tags: release
 ---
 
 zfp is a library for compressed numerical arrays that support high-throughput read and write random access. zfp also supports streaming compression of integer and floating-point data, e.g., for applications that read and write large data sets to and from disk. zfp is primarily written in C and C++ but also includes Python and Fortran bindings.

--- a/_posts/2019-05-06-lmt-3.2.6.md
+++ b/_posts/2019-05-06-lmt-3.2.6.md
@@ -1,6 +1,6 @@
 ---
 title: "LMT 3.2.6 Released"
-tags: new-release
+tags: release
 ---
 
 The Lustre Monitoring Tools (LMT) repo is a distributed system that provides a "top"-like display of the activity levels of the server-side (MDS, OSSes, and LNET routers) nodes of one or more Lustre-based filesystems. This release includes support for Lustre 2.12.0.

--- a/_posts/2019-05-07-cct-1.0.4.M3.md
+++ b/_posts/2019-05-07-cct-1.0.4.M3.md
@@ -1,6 +1,6 @@
 ---
 title: "CCT 1.0.4-M3 Released"
-tags: new-release
+tags: release
 ---
 
 The Coda Calibration Tool (CCT) calculates reliable moment magnitudes for small- to moderate-sized seismic events. This release contains many improvements and updates, including:

--- a/_posts/2019-05-08-goldstone-redhat.md
+++ b/_posts/2019-05-08-goldstone-redhat.md
@@ -1,6 +1,6 @@
 ---
 title: "Video: LLNL at the 2019 Red Hat Summit"
-tags: multimedia trip-report
+tags: event-report multimedia
 ---
 
 At the recent Red Hat Summit in Boston, LLNL's Robin Goldstone discussed open-source technologies and the Sierra supercomputer. Goldstone, an HPC solutions architect, said "open source makes perfect sense" for scalability and performance in an HPC center like LLNL's. She stated, "We have all that visibility and that software. If it doesn't work for our needs, we can make it work for our needs. And then we can give it back to the community because even though people aren't doing things at the scale that we are today, a lot of the things that we're doing really do trickle down and be used by a lot of other people." A transcript of her interview is included with the [video](https://video.cube365.net/c/914449), which runs 15:28.

--- a/_posts/2019-05-14-ccloud-0.9.10.md
+++ b/_posts/2019-05-14-ccloud-0.9.10.md
@@ -1,6 +1,6 @@
 ---
 title: "Charliecloud 0.9.10 Released"
-tags: new-release
+tags: release
 ---
 
 LANL led with LLNL contributors, Charliecloud provides user-defined software stacks for HPC centers. It uses Linux user namespaces to run containers with no privileged operations or daemons and minimal configuration changes on center resources.

--- a/_posts/2019-05-14-lbann-0.99.md
+++ b/_posts/2019-05-14-lbann-0.99.md
@@ -1,6 +1,6 @@
 ---
 title: "LBANN 0.99 Released"
-tags: new-release
+tags: release
 ---
 
 The Livermore Big Artificial Neural Network toolkit (LBANN) is an open-source, HPC-centric, deep learning training framework that is optimized to compose multiple levels of parallelism. 

--- a/_posts/2019-05-23-zfsonlinux-0.8.0.md
+++ b/_posts/2019-05-23-zfsonlinux-0.8.0.md
@@ -1,6 +1,6 @@
 ---
 title: "ZFS on Linux 0.8.0 Released"
-tags: new-release
+tags: release
 ---
 
 The Livermore Big Artificial Neural Network toolkit (LBANN) is an open-source, HPC-centric, deep learning training framework that is optimized to compose multiple levels of parallelism. 

--- a/_posts/2019-05-24-mfem-4.0.md
+++ b/_posts/2019-05-24-mfem-4.0.md
@@ -1,6 +1,6 @@
 ---
 title: "MFEM 4.0 Released"
-tags: new-release
+tags: release
 ---
 
 [Version 4.0](https://github.com/mfem/mfem/blob/v4.0/CHANGELOG) of [MFEM](https://mfem.org), a lightweight, general, scalable C++ library for finite element methods, is now available.

--- a/_posts/2019-06-01-magpie-2.3.md
+++ b/_posts/2019-06-01-magpie-2.3.md
@@ -1,6 +1,6 @@
 ---
 title: "Magpie 2.3 Released"
-tags: new-release
+tags: release
 ---
 
 Magpie contains a number of scripts for running big data software in HPC environments. It currently supports running over the parallel file system Lustre and running over any generic network filesystem. There is scheduler/resource manager support for Slurm, Moab, Torque, and LSF.

--- a/_posts/2019-06-11-umpire-0.3.5.md
+++ b/_posts/2019-06-11-umpire-0.3.5.md
@@ -1,6 +1,6 @@
 ---
 title: "Umpire 0.3.5 Released"
-tags: new-release
+tags: release
 ---
 
 Umpire is a resource management library that allows the discovery, provision, and management of memory on next-generation architectures. v0.3.4 and v0.3.5 together include bug fixes for `AllocationMap`.

--- a/_posts/2019-06-14-blt-0.2.5.md
+++ b/_posts/2019-06-14-blt-0.2.5.md
@@ -1,6 +1,6 @@
 ---
 title: "BLT 0.2.5 Released"
-tags: new-release
+tags: release
 ---
 
 BLT (Building, Linking, and Testing) is a streamlined CMake build system foundation for developing HPC software. BLT makes it easy to get up and running on a wide range of HPC compilers (e.g., gcc, clang), operating systems (e.g., Linux, Mac OS, Windows), and technologies (e.g., MPI, OpenMP, CUDA). BLT also includes unit testing and benchmarking.

--- a/_posts/2019-06-18-kripke-1.2.4.md
+++ b/_posts/2019-06-18-kripke-1.2.4.md
@@ -1,6 +1,6 @@
 ---
 title: "Kripke 1.2.4 Released"
-tags: new-release
+tags: release
 ---
 
 Kripke is a simple, scalable, 3D Sn deterministic particle transport code. Its primary purpose is to research how data layout, programming paradigms and architectures effect the implementation and performance of Sn transport. A main goal of Kripke is investigating how different data-layouts effect instruction, thread and task level parallelism, and what the implications are on overall solver performance. v1.2.4 changes the software license to BSD 3-clause.

--- a/_posts/2019-06-24-sundials-5.0.0.md
+++ b/_posts/2019-06-24-sundials-5.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: "SUNDIALS 5.0.0-dev.1 Released"
-tags: new-release
+tags: release
 ---
 
 SUNDIALS is a SUite of Nonlinear and DIfferential/ALgebraic equation Solvers. This version is a beta release of the next major SUNDIALS version and offers a preview of what is to come, including

--- a/_posts/2019-06-25-caliper-2.1.0.md
+++ b/_posts/2019-06-25-caliper-2.1.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Caliper 2.1.0 Released"
-tags: new-release
+tags: release
 ---
 
 Caliper is a program instrumentation and performance measurement framework. It is designed as a performance analysis toolbox in a library, allowing one to bake performance analysis capabilities directly into applications and activate them at runtime. This release includes several improvements and new features:

--- a/_posts/2019-06-26-umap-2.0.0.md
+++ b/_posts/2019-06-26-umap-2.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: "umap 2.0.0 Released"
-tags: new-release
+tags: release
 ---
 
 Umap is a library that provides an mmap()-like interface to a simple, user- space page fault handler based on the userfaultfd Linux feature. The use case is to have an application specific buffer of pages cached from a large file (i.e. out-of-core execution using memory map). This release includes:

--- a/_posts/2019-07-08-macpatch-3.3.0.2.md
+++ b/_posts/2019-07-08-macpatch-3.3.0.2.md
@@ -1,6 +1,6 @@
 ---
 title: "MacPatch 3.3.0.2 released"
-tags: new-release
+tags: release
 ---
 
 MacPatch -- used at LLNL to manage 3,000+ computers -- simplifies the act of patching and installing software on Mac OS X based systems. The client relies on using the built-in software update application for patching the Mac OS X system updates and its own scan and patch engine for custom patches. v3.3.0.2 is a major release with a completely new UI and the backend updated to Python 3.

--- a/_posts/2019-07-10-hypre-2.17.md
+++ b/_posts/2019-07-10-hypre-2.17.md
@@ -1,6 +1,6 @@
 ---
 title: "Hypre 2.17 Released"
-tags: new-release
+tags: release
 ---
 
 Hypre is a library of high-performance preconditioners and solvers featuring multigrid methods for the solution of large, sparse linear systems of equations on massively parallel computers. [Version 2.17](https://github.com/hypre-space/hypre/releases/tag/v2.17.0) changes the license from GNU to [Apache 2.0](https://github.com/hypre-space/hypre/blob/master/LICENSE-APACHE)/[MIT](https://github.com/hypre-space/hypre/blob/master/LICENSE-MIT).

--- a/_posts/2019-07-15-visit-3.0.1.md
+++ b/_posts/2019-07-15-visit-3.0.1.md
@@ -1,6 +1,6 @@
 ---
 title: "VisIt 3.0.1 Released"
-tags: new-release
+tags: release
 ---
 
 VisIt is an Open Source, interactive, scalable, visualization, animation and analysis tool. Among the enhancements included in v3.0.1 are:

--- a/_posts/2019-07-16-ccloud-0.10.md
+++ b/_posts/2019-07-16-ccloud-0.10.md
@@ -1,6 +1,6 @@
 ---
 title: "Charliecloud 0.10 Released"
-tags: new-release
+tags: release
 ---
 
 LANL led with LLNL contributors, Charliecloud provides user-defined software stacks for HPC centers. It uses Linux user namespaces to run containers with no privileged operations or daemons and minimal configuration changes on center resources.

--- a/_posts/2019-07-17-ceed-2.0.md
+++ b/_posts/2019-07-17-ceed-2.0.md
@@ -1,6 +1,6 @@
 ---
 title: "CEED’s Impact on Exascale Computing Project Efforts Is Wide-Ranging"
-tags: new-release
+tags: release
 ---
 
 The Center for Efficient Exascale Discretizations (CEED) within the US Department of Energy’s ECP is helping applications leverage future architectures by developing state-of-the-art discretization algorithms that better exploit the hardware and deliver a significant performance gain over conventional methods. The focus is on high-order methods for high-fidelity and better machine utilization, with a range of orders providing flexibility in uncertain hardware and software environments.

--- a/_posts/2019-07-25-raja-0.9.0.md
+++ b/_posts/2019-07-25-raja-0.9.0.md
@@ -1,6 +1,6 @@
 ---
 title: "RAJA 0.9.0 Released"
-tags: new-release
+tags: release
 ---
 
 RAJA is a software abstraction that systematically encapsulates platform-specific code to enable applications to be portable across diverse hardware architectures without major source code disruption. The v.0.9.0 release includes new features:

--- a/_posts/2019-08-03-umpire-1.0.0.md
+++ b/_posts/2019-08-03-umpire-1.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Umpire 1.0.0 Released"
-tags: new-release
+tags: release
 ---
 
 Umpire is a resource management library that allows the discovery, provision, and management of memory on next-generation architectures. With v1.0.0, Umpire is MPI-aware, and `AllocationStrategies` may be wrapped with multiple extra layers. Additional changes include directing log and replay output to files, one per process.

--- a/_posts/2019-08-05-chai-1.2.0.md
+++ b/_posts/2019-08-05-chai-1.2.0.md
@@ -1,6 +1,6 @@
 ---
 title: "CHAI 1.2.0 Released"
-tags: new-release
+tags: release
 ---
 
 The [CHAI library](https://github.com/LLNL/CHAI) handles automatic data migration to different memory spaces behind an array-style interface. It was designed to work with [RAJA](https://github.com/LLNL/RAJA) and integrates with it. CHAI may be used with other C++ abstractions as well. [v1.2.0](https://github.com/LLNL/CHAI/releases/tag/v1.2.0) contains support for AMD devices using HIP as well as updates for the 1.0.0 release of [Umpire](https://github.com/LLNL/umpire).

--- a/_posts/2019-08-14-cct-1.0.5.md
+++ b/_posts/2019-08-14-cct-1.0.5.md
@@ -1,6 +1,6 @@
 ---
 title: "CCT 1.0.5 Released"
-tags: new-release
+tags: release
 ---
 
 The Coda Calibration Tool (CCT) calculates reliable moment magnitudes for small- to moderate-sized seismic events. This release contains performance improvements and other updates, namely:

--- a/_posts/2019-08-22-juliacon.md
+++ b/_posts/2019-08-22-juliacon.md
@@ -1,6 +1,6 @@
 ---
 title: "JuliaCon Recap and Videos"
-tags: multimedia trip-report
+tags: event-report multimedia
 ---
 
 LLNL’s [Seth Bromberger](https://github.com/orgs/LLNL/people/sbromberger) attended [JuliaCon 2019](https://juliacon.org) on July 22–25 in Baltimore, Maryland. He gave a talk on July 24 to a full house: “Using Julia in Secure Environments” ([abstract](https://pretalx.com/juliacon2019/talk/JANJFM/), [YouTube video](https://youtu.be/o8UBszD_zn4)). The focus of the presentation was engaging the community in thinking about transitive package dependencies and the security of the source code supply chain.

--- a/_posts/2019-09-16-umpire-1.1.0.md
+++ b/_posts/2019-09-16-umpire-1.1.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Umpire 1.1.0 Released"
-tags: new-release
+tags: release
 ---
 
 Umpire is a resource management library that allows the discovery, provision, and management of memory on next-generation architectures. v1.1.0 includes upgrades to detect version mismatches when linking multiple libraries, fixes to signature of C function, and updated pool algorithm.

--- a/_posts/2019-09-17-ccloud-0.11.md
+++ b/_posts/2019-09-17-ccloud-0.11.md
@@ -1,6 +1,6 @@
 ---
 title: "Charliecloud 0.11 Released"
-tags: new-release
+tags: release
 ---
 
 LANL led with LLNL contributors, Charliecloud provides user-defined software stacks for HPC centers. It uses Linux user namespaces to run containers with no privileged operations or daemons and minimal configuration changes on center resources. This simple approach avoids most security risks while maintaining access to the performance and functionality already on offer.

--- a/_posts/2019-09-18-libceed-0.5.md
+++ b/_posts/2019-09-18-libceed-0.5.md
@@ -1,6 +1,6 @@
 ---
 title: "libCEED 0.5 Released"
-tags: new-release
+tags: release
 ---
 
 The Center for Efficient Exascale Discretizations ([CEED](https://github.com/CEED)) within the US Department of Energy’s ECP is helping applications leverage future architectures by developing state-of-the-art discretization algorithms that better exploit the hardware and deliver a significant performance gain over conventional methods. [libCEED](https://github.com/CEED/libCEED) is a high-order API library that provides a common algebraic low-level operator description, allowing a wide variety of applications to take advantage of the efficient operator evaluation algorithms in the different CEED packages. libCEED is a C99 library with no external dependencies.

--- a/_posts/2019-09-18-sundials-5.0.0.md
+++ b/_posts/2019-09-18-sundials-5.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: "SUNDIALS 5.0.0-dev.2 Released"
-tags: new-release
+tags: release
 ---
 
 SUNDIALS is a SUite of Nonlinear and DIfferential/ALgebraic equation Solvers. This release includes:

--- a/_posts/2019-09-24-visit-3.0.2.md
+++ b/_posts/2019-09-24-visit-3.0.2.md
@@ -1,6 +1,6 @@
 ---
 title: "VisIt 3.0.2 Released"
-tags: new-release
+tags: release
 ---
 
 VisIt is an Open Source, interactive, scalable, visualization, animation and analysis tool. Among the enhancements included in v3.0.2 are:

--- a/_posts/2019-10-03-unify-0.9.0.md
+++ b/_posts/2019-10-03-unify-0.9.0.md
@@ -1,6 +1,6 @@
 ---
 title: "UnifyFS 0.9.0 Released"
-tags: new-release
+tags: release
 ---
 
 Unify is a suite of specialized, flexible file systems that can be included in a user’s job allocations. Formerly known as UnifyCR (for checkpoint/restart), UnifyFS supports scalable and efficient aggregation of I/O bandwidth from burst buffers while having the same life cycle as a batch-submitted job.

--- a/_posts/2019-10-21-sundials-5.0.0.md
+++ b/_posts/2019-10-21-sundials-5.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: "SUNDIALS 5.0.0 Released"
-tags: new-release
+tags: release
 ---
 
 SUNDIALS is a SUite of Nonlinear and DIfferential/ALgebraic equation Solvers. Incremental v5.0.0 releases occurred in March, June, and September. This complete release includes:

--- a/_posts/2019-10-25-spack-0.13.md
+++ b/_posts/2019-10-25-spack-0.13.md
@@ -1,6 +1,6 @@
 ---
 title: "Spack 0.13 Released"
-tags: new-release
+tags: release
 ---
 
 [Spack](https://github.com/spack) is a flexible, configurable, Python-based, and open-source HPC package manager. Spack automates the installation and fine-tuning of simulations and libraries, operating on a wide variety of HPC platforms and enabling users to build many code configurations.

--- a/_posts/2019-10-26-conduit-0.5.md
+++ b/_posts/2019-10-26-conduit-0.5.md
@@ -1,6 +1,6 @@
 ---
 title: "Conduit 0.5 Released"
-tags: new-release
+tags: release
 ---
 
 Conduit provides an intuitive model for describing hierarchical scientific data in C++, C, Fortran, and Python. It is used for data coupling between packages in-core, serialization, and I/O tasks. The Core API provides a flexible way to describe and access hierarchical data. v0.5 includes:

--- a/_posts/2019-10-30-raja-0.10.0.md
+++ b/_posts/2019-10-30-raja-0.10.0.md
@@ -1,6 +1,6 @@
 ---
 title: "RAJA 0.10.0 Released"
-tags: new-release
+tags: release
 ---
 
 RAJA is a software abstraction that systematically encapsulates platform-specific code to enable applications to be portable across diverse hardware architectures without major source code disruption. The v.0.10.0 release includes new features:

--- a/_posts/2019-11-04-ccloud-0.12.md
+++ b/_posts/2019-11-04-ccloud-0.12.md
@@ -1,6 +1,6 @@
 ---
 title: "Charliecloud 0.12 Released"
-tags: new-release
+tags: release
 ---
 
 LANL led with LLNL contributors, Charliecloud provides user-defined software stacks for HPC centers. It uses Linux user namespaces to run containers with no privileged operations or daemons and minimal configuration changes on center resources. This simple approach avoids most security risks while maintaining access to the performance and functionality already on offer.

--- a/_posts/2019-11-07-cct-1.0.7.md
+++ b/_posts/2019-11-07-cct-1.0.7.md
@@ -1,6 +1,6 @@
 ---
 title: "CCT 1.0.7 Released"
-tags: new-release
+tags: release
 ---
 
 The Coda Calibration Tool (CCT) calculates reliable moment magnitudes for small- to moderate-sized seismic events. This release contains several new features, including:

--- a/_posts/2019-11-08-esgfuk.md
+++ b/_posts/2019-11-08-esgfuk.md
@@ -1,6 +1,6 @@
 ---
 title: "ESGF Architecture Workshop"
-tags: trip-report
+tags: event-report
 ---
 
 Members of the [Earth System Grid Federation (ESGF)](https://github.com/esgf) gathered in Abingdon, England, on November 5-7 to kick off the redesign process for the Federation's computing architecture. Since the original system was designed a decade ago, the number of ESGF's supported projects and disciplines has grown and diversified. Furthermore, operational requirements are clearer for the ESGF to support an international federated archive of this size. Many of the ESGF nodes now have other functions beyond CMIP (the Coupled Model Intercomparison Project), and the landscape of data repository and science needs has changed.

--- a/_posts/2019-11-12-sweng101talk.md
+++ b/_posts/2019-11-12-sweng101talk.md
@@ -1,6 +1,6 @@
 ---
 title: "Software Engineering 101: I have some code! Now what?"
-tags: trip-report, story, this-website
+tags: event-report story this-website
 ---
 
 As part of LLNL’s _Computing 101_ speaker series, Ian Lee gave a talk to employees on November 12 titled “Software Engineering 101: I have some code! Now what?” The presentation reviewed the Lab’s resources for supporting software engineering and open source development.

--- a/_posts/2019-11-13-caliper-2.2.0.md
+++ b/_posts/2019-11-13-caliper-2.2.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Caliper 2.12.0 Released"
-tags: new-release
+tags: release
 ---
 
 Caliper is a program instrumentation and performance measurement framework. It is designed as a performance analysis toolbox in a library, allowing one to bake performance analysis capabilities directly into applications and activate them at runtime. The latest release includes several improvements and new features, such as:

--- a/_posts/2019-11-22-sc19bestpaper.md
+++ b/_posts/2019-11-22-sc19bestpaper.md
@@ -1,6 +1,6 @@
 ---
 title: "LLNL-Led Team Wins SC19 Best Paper Award"
-tags: story, trip-report
+tags: event-report story
 ---
 
 On November 22, a panel of judges at the International Conference for High Performance Computing, Networking, Storage and Analysis (SC19) awarded a multi-institutional team led by LLNL computer scientists with the conference’s Best Paper award. The [paper](http://www.sci.utah.edu/~hbhatia/pubs/2019_SC_MUMMI.pdf), entitled “Massively Parallel Infrastructure for Adaptive Multiscale Simulations: Modeling RAS Initiation Pathway for Cancer,” describes the workflow driving a first-of-its-kind multiscale simulation on predictively modeling the dynamics of RAS proteins&mdash;a family of proteins whose mutations are linked to more than 30 percent of all human cancers&mdash;and their interactions with lipids, the organic compounds that help make up cell membranes.

--- a/_posts/2019-12-04-maestrowf-1.1.6.md
+++ b/_posts/2019-12-04-maestrowf-1.1.6.md
@@ -1,6 +1,6 @@
 ---
 title: "Maestrowf 1.1.6 Released"
-tags: new-release
+tags: release
 ---
 
 Maestrowf is a tool for specifying and conducting general workflows locally and on supercomputers. Maestro parses a human-readable YAML specification that is self-documenting and portable from one user and environment to another. This release contains new features such as:

--- a/_posts/2019-12-04-spack-0.13.2.md
+++ b/_posts/2019-12-04-spack-0.13.2.md
@@ -1,6 +1,6 @@
 ---
 title: "Spack 0.13.2 Released"
-tags: new-release
+tags: release
 ---
 
 [Spack](https://github.com/spack) is a flexible, configurable, Python-based, and open-source HPC package manager. Spack automates the installation and fine-tuning of simulations and libraries, operating on a wide variety of HPC platforms and enabling users to build many code configurations.

--- a/_posts/2019-12-05-sc19recap.md
+++ b/_posts/2019-12-05-sc19recap.md
@@ -1,6 +1,6 @@
 ---
 title: "LLNL’s Presence in HPC Shines Bright at SC19"
-tags: trip-report
+tags: event-report
 ---
 
 The 2019 International Conference for High Performance Computing, Networking, Storage, and Analysis&mdash;better known simply as SC19&mdash;returned to Denver, and once again LLNL made its presence known as a force in supercomputing. The conference, held November 17 through 22, was attended by nearly 14,000 people representing 118 countries.

--- a/_posts/2019-12-12-chai-2.0.0.md
+++ b/_posts/2019-12-12-chai-2.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: "CHAI 2.0.0 Released"
-tags: new-release
+tags: release
 ---
 
 [CHAI](https://github.com/LLNL/CHAI) is a C++ library providing an array object that can be used transparently in multiple memory spaces. CHAI can be used standalone, but is best when paired with the RAJA library, which has built-in CHAI integration that takes care of everything. This release includes a major refactoring of the integration with the [RAJA](https://github.com/LLNL/RAJA/) performance portability layer. CHAI now provides an `ENABLE_RAJA_PLUGIN` option that will build a plugin for RAJA enabling automatic data migration when CHAI and RAJA are linked in the same application.

--- a/_posts/2019-12-12-hatchet-1.0.0.md
+++ b/_posts/2019-12-12-hatchet-1.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Hatchet 1.0.0 Released"
-tags: new-release
+tags: release
 ---
 
 [Hatchet](https://github.com/LLNL/hatchet) is a Python-based library that allows Pandas dataframes to be indexed by structured tree and graph data. Version 1.0.0 is the first major release of this software.

--- a/_posts/2019-12-19-rajaperf-0.6.0.md
+++ b/_posts/2019-12-19-rajaperf-0.6.0.md
@@ -1,6 +1,6 @@
 ---
 title: "RAJAPerf 0.6.0 Released"
-tags: new-release
+tags: release
 ---
 
 The RAJA performance suite (RAJAPerf) is designed to explore performance of loop-based computational kernels found in HPC applications. v0.6.0 contains two new variants of each kernel (`sequential-lambda` and `OpenMP-lambda`) and several new kernels.

--- a/_posts/2020-01-08-blt-0.3.0.md
+++ b/_posts/2020-01-08-blt-0.3.0.md
@@ -1,6 +1,6 @@
 ---
 title: "BLT 0.3.0 Released"
-tags: new-release
+tags: release
 ---
 
 [BLT (Building, Linking, and Testing)](https://github.com/LLNL/blt) is a streamlined CMake build system foundation for developing HPC software. BLT makes it easy to get up and running on a wide range of HPC compilers, operating systems, and technologies. The repo includes unit testing and benchmarking. The v0.3.0 release includes support for target property macros, custom target names, and Cray compilers.

--- a/_posts/2020-01-08-sundials-5.1.0.md
+++ b/_posts/2020-01-08-sundials-5.1.0.md
@@ -1,6 +1,6 @@
 ---
 title: "SUNDIALS 5.1.0 Released"
-tags: new-release
+tags: release
 ---
 
 [SUNDIALS](https://github.com/LLNL/sundials) is a SUite of Nonlinear and DIfferential/ALgebraic equation Solvers. Building off the v5.0.0 release in October, this release includes new utility functions, added support for a user-supplied function to update the prediction for each implicit stage solution in ARKStep, an updated MRIStep module, and more.

--- a/_posts/2020-01-13-umpire-2.0.0.md
+++ b/_posts/2020-01-13-umpire-2.0.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Umpire 2.0.0 Released"
-tags: new-release
+tags: release
 ---
 
 [Umpire](https://github.com/LLNL/Umpire) is a resource management library that allows the discovery, provision, and management of memory on next-generation architectures. v2.0.0 includes API changes and some new parameters.

--- a/_posts/2020-01-14-ccloud-0.13.md
+++ b/_posts/2020-01-14-ccloud-0.13.md
@@ -1,6 +1,6 @@
 ---
 title: "Charliecloud 0.13 Released"
-tags: new-release
+tags: release
 ---
 
 LANL led with LLNL contributors, [Charliecloud](https://github.com/hpc/charliecloud) provides user-defined software stacks for HPC centers. It uses Linux user namespaces to run containers with no privileged operations or daemons and minimal configuration changes on center resources. In v0.13, the build system was rewritten, and the layout of the source code and installed files were changed significantly.

--- a/_posts/2020-01-18-conduit-0.5.1.md
+++ b/_posts/2020-01-18-conduit-0.5.1.md
@@ -1,6 +1,6 @@
 ---
 title: "Conduit 0.5.1 Released"
-tags: new-release
+tags: release
 ---
 
 [Conduit](https://github.com/LLNL/conduit) provides an intuitive model for describing hierarchical scientific data in C++, C, Fortran, and Python. It is used for data coupling between packages in-core, serialization, and I/O tasks. The Core API provides a flexible way to describe and access hierarchical data. v0.5.1 includes:

--- a/_posts/2020-01-23-merlin-1.2.0.md
+++ b/_posts/2020-01-23-merlin-1.2.0.md
@@ -1,6 +1,6 @@
 ---
 title: "Merlin 1.2.0 Released"
-tags: new-release
+tags: release
 ---
 
 [Merlin](https://github.com/LLNL/merlin) is a tool for running machine learning based workflows. The goal of Merlin is to make it easy to build, run, and process the kinds of large scale HPC workflows needed for cognitive simulation. Merlin is a distributed task queuing system, designed to allow complex HPC workflows to scale to large numbers of simulations. v1.2.0 includes:

--- a/_posts/2020-01-27-raja-0.11.0.md
+++ b/_posts/2020-01-27-raja-0.11.0.md
@@ -1,6 +1,6 @@
 ---
 title: "RAJA 0.11.0 Released"
-tags: new-release
+tags: release
 ---
 
 [RAJA](https://github.com/LLNL/raja) is a software abstraction that systematically encapsulates platform-specific code to enable applications to be portable across diverse hardware architectures without major source code disruption.

--- a/_posts/2020-02-02-fosdemrecap.md
+++ b/_posts/2020-02-02-fosdemrecap.md
@@ -1,6 +1,6 @@
 ---
 title: "Video: Spack at FOSDEM '20"
-tags: trip-report, multimedia
+tags: event-report multimedia
 ---
 
 FOSDEM is an annual two-day event promoting the widespread use of free and open source software. The 2020 conference took place in Brussels, Belgium, on February 1–2. Videos of speakers, lightning talks, and other sessions are available on the [FOSDEM website](https://fosdem.org/2020/schedule/events/). LLNL's Todd Gamblin led two sessions about the package manager [Spack](https://github.com/spack):

--- a/_posts/2020-02-10-rajaperf-0.7.0.md
+++ b/_posts/2020-02-10-rajaperf-0.7.0.md
@@ -1,6 +1,6 @@
 ---
 title: "RAJAPerf 0.7.0 Released"
-tags: new-release
+tags: release
 ---
 
 The RAJA performance suite ([RAJAPerf](https://github.com/LLNL/RAJAPerf)) is designed to explore performance of loop-based computational kernels found in HPC applications. Specifically, it is used to assess, monitor, and compare runtime performance of kernels implemented using RAJA and variants implemented using standard or vendor-supported parallel programming models directly. Each kernel in the suite appears in multiple RAJA and non-RAJA (i.e., baseline) variants using parallel programming models such as OpenMP and CUDA. The v0.7.0 release updates the RAJA submodule to v0.11.0 and the BLT submodule to v0.3.0.

--- a/news/README.md
+++ b/news/README.md
@@ -3,19 +3,19 @@
 News posts appear on the [News](https://software.llnl.gov/news/) and [Archive](https://software.llnl.gov/news/archive/) pages in reverse chronological order (i.e., newest first). The list is curated to promote LLNL's open source endeavors and community engagement. Posts should be tagged with at least one of the following topics, which are not associated with the [category tags](https://github.com/LLNL/llnl.github.io/tree/master/category) applied to repos:
 
 - `event` - announcement of an upcoming event/conference
+- `event-report` - recap of an event/conference
 - `multimedia` - synopsis of a video or podcast published on another platform (e.g., YouTube)
-- `new-release` - announcement of substantial software release (i.e., more than bug fixes)
 - `new-repo` - announcement of new repo added to LLNL's software catalog
 - `profile` - profile of a developer
+- `release` - announcement of substantial software release (i.e., more than bug fixes)
 - `story` - synopsis of a relevant news or research-focused article
 - `this-website` - announcement of feature enhancement or other changes to this site
-- `trip-report` - recap of an event/conference
 
-Tags should appear in each post's front matter under the title and separated by commas:
+Tags should appear alphabetically in each post's frontmatter under the title, with no punctuation between multiple tags:
 
 ```
 title: "Title of Post"
-tags: new-repo, story
+tags: new-repo story
 ```
 
 LLNL's [.github repo](https://github.com/LLNL/.github/tree/master/news-templates) contains .md templates for each of these types of posts. For posts that combine multiple tags (e.g., multimedia, event), a combination of templates may be used. File naming conventions are also provided.


### PR DESCRIPTION
Partially fulfills issue #252.
- Changed `trip-report` to `event-report`
- Changed `new-release` to `release`
- Removed stray commas between tags when >1
- Alphabetized tags when >1
- Updated News README to reflect changes