### PR TITLE
Update location of ZFS repo

### DIFF
--- a/_explore/input_lists.json
+++ b/_explore/input_lists.json
@@ -13,8 +13,7 @@
         "pruners",
         "rose-compiler",
         "spack",
-        "visit-dav",
-        "zfsonlinux"
+        "visit-dav"
     ],
     "repos": [
         "alpine-dav/ascent",
@@ -28,6 +27,7 @@
         "hpc/mpifileutils",
         "hpc/openlorenz",
         "hpc/spindle",
+        "openzfs/zfs",
         "sabersw/pysaber",
         "shusenl/nlpvis",
         "xbraid/xbraid"

--- a/_explore/input_lists.json
+++ b/_explore/input_lists.json
@@ -10,6 +10,7 @@
         "hypre-space",
         "llnl",
         "mfem",
+        "openzfs",
         "pruners",
         "rose-compiler",
         "spack",
@@ -27,7 +28,6 @@
         "hpc/mpifileutils",
         "hpc/openlorenz",
         "hpc/spindle",
-        "openzfs/zfs",
         "sabersw/pysaber",
         "shusenl/nlpvis",
         "xbraid/xbraid"


### PR DESCRIPTION
It moved from https://github.com/zfsonlinux/zfs to https://github.com/openzfs/zfs