### PR TITLE
Changed the way Archive called categories

### DIFF
--- a/news/archive.md
+++ b/news/archive.md
@@ -15,7 +15,7 @@ permalink: /news/archive/
                     <article class="news">
                         <h3>
                             {{post.title}}
-                            <small class="pull-right">{{ post.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
+                            <small class="pull-right">{{ post.date | date: '%B %d, %Y' }} {% for categories in post.categories %} ({{ categories }}) {% endfor %}</small>
                         </h3>
 
                         {{ post.content }}


### PR DESCRIPTION
Closes issue #336. Not an oversight after all. Turns out Archive has to refer to `post.categories` whereas News and Events refer to `page.categories`. I guess this is because of the way the Archive wraps content by year. ? In any case, categories now display in parentheses next to the post title like they do on the other two pages.