### PR TITLE
Move Abhinav Bhatele's repos to his hpcgroup at UMD

### DIFF
--- a/_explore/input_lists.json
+++ b/_explore/input_lists.json
@@ -28,6 +28,13 @@
         "hpc/mpifileutils",
         "hpc/openlorenz",
         "hpc/spindle",
+        "hpcgroup/AriesNCL",
+        "hpcgroup/BGQNCL",
+        "hpcgroup/chatterbug",
+        "hpcgroup/damselfly",
+        "hpcgroup/graphator",
+        "hpcgroup/TraceR",
+        "hpcgroup/tracer-examples",
         "sabersw/pysaber",
         "shusenl/nlpvis",
         "xbraid/xbraid"


### PR DESCRIPTION
@bhatele moved from LLNL to UMD, and he's got a new organization for his projects: @hpcgroup.  

The projects have already been transferred there; this ensures that we continue to reference them on https://software.llnl.gov.

These are the projects:
* https://github.com/hpcgroup/AriesNCL
* https://github.com/hpcgroup/BGQNCL
* https://github.com/hpcgroup/chatterbug
* https://github.com/hpcgroup/damselfly
* https://github.com/hpcgroup/graphator
* https://github.com/hpcgroup/TraceR
* https://github.com/hpcgroup/tracer-examples