### PR TITLE
Remove most recent week from line graph

### DIFF
--- a/js/explore/line_repoActivity.js
+++ b/js/explore/line_repoActivity.js
@@ -19,6 +19,9 @@ function draw_line_repoActivity(areaID, repoNameWOwner) {
             graphHeader = "Activity for '" + repoNameWOwner + "' [Default Branch, 1 Year]";
         }
 
+        // Removes most recent week from graph to avoid apparent did in activity
+        data.pop();
+
         data.forEach(function(d) {
             d.date = parseTime(d.date);
             d.value = +d.value;

--- a/js/explore/line_repoActivity.js
+++ b/js/explore/line_repoActivity.js
@@ -19,7 +19,7 @@ function draw_line_repoActivity(areaID, repoNameWOwner) {
             graphHeader = "Activity for '" + repoNameWOwner + "' [Default Branch, 1 Year]";
         }
 
-        // Removes most recent week from graph to avoid apparent did in activity
+        // Removes most recent week from graph to avoid apparent dip in activity
         data.pop();
 
         data.forEach(function(d) {


### PR DESCRIPTION
The way we currently display data makes it appear that the number of commits has dropped significantly. This is because commits are logged per week and thus by graphing the current week, there are often very few commits recorded. To fix this, I have removed the current week from data before processing.