### PR TITLE
Lag reduction, addition of "Other" category, and more descriptive labels

### DIFF
--- a/js/explore/sunburst_licenses.js
+++ b/js/explore/sunburst_licenses.js
@@ -143,6 +143,7 @@ function draw_sunburst_licenses(areaID) {
                                 }
                             });
             
+            // Removes labels that will never be visible. This helps in lag reduction.
             label = label.filter(d => labelEverVisible(d));
             
             // Creates blank circle in center with click event to go up one level
@@ -244,7 +245,7 @@ function draw_sunburst_licenses(areaID) {
             }
             // Use long name if no short name
             let licenseName = licenseInfo['spdxId'] == null || licenseInfo['spdxId'] == 'NOASSERTION' ? licenseInfo['name'] : licenseInfo['spdxId'];
-            // Skip if no license name or name is 'Other'
+            // Skip if no license name
             if (licenseName == null) {
                 continue;
             }


### PR DESCRIPTION
Partially addresses #367 by adding "Other" to the license wheel. Adding this large of a group caused the lag on the graphic to become too large, so a filter was used to eliminate some of the lag, which decreased the lag to below pre-"Other"-addition levels. The labels on the slider are now also more descriptive.

![image](https://user-images.githubusercontent.com/29114346/86953639-8b0d6a00-c109-11ea-8c2e-056d2b2d614c.png)
