### PR TITLE
Cleaner query

### DIFF
--- a/_explore/queries/repo-Dependencies.gql
+++ b/_explore/queries/repo-Dependencies.gql
@@ -1,6 +1,6 @@
 query ($ownName: String!, $repoName: String!, $numManifests: Int!, $numDependents: Int!, $pgCursor: String) {
   repository(owner: $ownName, name: $repoName) {
-    dependencyGraphManifests(first: $numManifests, after: $pgCursor, dependenciesFirst: $numDependents) {
+    dependencyGraphManifests(first: $numManifests, after: $pgCursor, dependenciesFirst: $numDependents, withDependencies: true) {
       nodes {
         dependencies(first: $numDependents) {
           nodes {


### PR DESCRIPTION
A new feature was added to the github API that allows for a cleaner json by only querying repos with dependencies. It currently eliminates around a thousand useless lines of the json file.

Edit: I did not include the json file as I felt it would be gratuitous. I can add it in a commit if people think that would be useful.