### PR TITLE
Added new dependency subpage

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -42,8 +42,13 @@
         </li>
 
         <li id="explore"
-          {% if page.url == "/explore/" %} class="active"
-          {% endif %}><a class="navbar-normal" href="/explore/">Explore</a></li>
+            {% if page.url == "/explore/" %} class="active dropdown"
+            {% else %} class="dropdown"
+            {% endif %}><a class="navbar-normal" href="/explore/">Explore</a>
+          <div class="dropdown-content">
+            <p><a class="navbar-normal" href="/explore/dependencies/">Dependencies</a></p>
+          </div>
+        </li>
         <li id="github"><a href="https://github.com/llnl"><span class="fa fa-github fa-lg"></span></a></li>
         <li id="github"><a href="https://twitter.com/LLNL_OpenSource"><span class="fa fa-twitter fa-lg"></span></a></li>
       </ul>

--- a/explore/dependencies/index.html
+++ b/explore/dependencies/index.html
@@ -1,0 +1,46 @@
+---
+title: Explore
+layout: default
+---
+
+{% raw %}
+
+<link rel="stylesheet" type="text/css" href="../../css/graphstyle.css" />
+
+<h1 class="page-header text-center">
+    LLNL GitHub Visualizations
+</h1>
+
+<!-- Preset vis display areas -->
+<center>
+    <svg class="forceGraph"></svg> <svg class="connectionsTree"></svg>
+</center>
+
+<!-- Load basic D3 and helper scripts -->
+<script src="https://cdn.llnl.gov/d3/5.16.0/d3.min.js" charset="UTF-8"></script>
+<script type="text/javascript" src="https://cdn.llnl.gov/d3-tip/1.0/d3-tip.js"></script>
+<script type="text/javascript" src="https://cdn.llnl.gov/d3-v4-cloud/1.2.2/build/d3.layout.cloud.js"></script>
+<script type="text/javascript" src="https://cdn.llnl.gov/d3-simple-slider/1.8.0/d3-simple-slider.min.js"></script>
+<script type="text/javascript" src="../../js/explore/helpers.js"></script>
+
+<!-- Load drawing JS -->
+<script type="text/javascript" src="../../js/explore/force_dependencyGraph.js"></script>
+
+<script>
+    // GiHub Data Directory
+    var ghDataDir = '../github-data';
+    // Global chart standards
+    var stdTotalWidth = 500,
+        stdTotalHeight = 500;
+    var stdMargin = { top: 40, right: 40, bottom: 40, left: 40 },
+        stdWidth = stdTotalWidth - stdMargin.left - stdMargin.right,
+        stdHeight = stdTotalHeight - stdMargin.top - stdMargin.bottom,
+        stdMaxBuffer = 1.07;
+    var stdDotRadius = 4,
+        stdLgndDotRadius = 5,
+        stdLgndSpacing = 20;
+    // Call draw functions
+    draw_force_graph('forceGraph', 'connectionsTree');
+</script>
+
+{% endraw %}

--- a/explore/index.html
+++ b/explore/index.html
@@ -19,7 +19,6 @@ layout: default
     <br /><svg class="repoActivityChart"></svg>
     <br /><svg class="repoPulls"></svg><svg class="repoIssues"></svg>
     <br /><svg class="languageCloud"></svg><svg class="topicCloud"></svg>
-    <br /><svg class="forceGraph"></svg>
     <br /><svg class="licenseSunburst"></svg>
 </center>
 
@@ -41,7 +40,6 @@ layout: default
 <script type="text/javascript" src="../js/explore/cloud_topics.js"></script>
 <script type="text/javascript" src="../js/explore/sunburst_licenses.js"></script>
 <script type="text/javascript" src="../js/explore/pack_hierarchy.js"></script>
-<script type="text/javascript" src="../js/explore/force_graph.js"></script>
 
 <script>
     // GiHub Data Directory
@@ -65,7 +63,6 @@ layout: default
     draw_scatter_repoIssues('repoIssues');
     draw_cloud_languages('languageCloud');
     draw_cloud_topics('topicCloud');
-    draw_force_graph('forceGraph');
     draw_sunburst_licenses('licenseSunburst');
     draw_pack_hierarchy('hierarchyPack');
 </script>

--- a/js/explore/force_dependencyGraph.js
+++ b/js/explore/force_dependencyGraph.js
@@ -179,7 +179,7 @@ function draw_force_graph(areaID, adjacentAreaID) {
         // Options for graph view
         options.normalView = { name: 'normalView', text: 'Repos connected to dependencies', labels: ['LLNL Repositories with Dependencies', 'External Packages', 'Internal Packages'], function: redraw };
         options.simplifiedView = { name: 'simplifiedView', text: 'Repos connected by shared dependencies', labels: ['LLNL Repositories with Dependencies', 'External Packages', 'Internal Packages'], function: simplify };
-        options.orgView = { name: 'orgView', text: 'Organizations connected to verified dependecy organizations', labels: ['LLNL Organizations', 'External Package Organizations', 'LLNL Package Organizations'], function: organize };
+        options.orgView = { name: 'orgView', text: 'Organizations connected to dependency organizations', labels: ['LLNL Organizations', 'External Package Organizations', 'LLNL Package Organizations'], function: organize };
         options.simplifiedOrgView = { name: 'simplifiedOrgView', text: 'Organizations connected by shared dependencies', labels: ['LLNL Organizations', 'External Package Organizations', 'LLNL Package Organizations'], function: simplifyOrganize };
         const optionsArray = Object.values(options);
 

--- a/js/explore/force_graph.js
+++ b/js/explore/force_graph.js
@@ -169,7 +169,7 @@ function draw_force_graph(areaID) {
         // Options for graph view
         options.normalView = { name: 'normalView', text: 'Repos connected to dependencies', function: redraw };
         options.simplifiedView = { name: 'simplifiedView', text: 'Repos connected by shared dependencies', function: simplify };
-        options.orgView = { name: 'orgView', text: 'Organizations connected to dependecy organizations', function: organize };
+        options.orgView = { name: 'orgView', text: 'Organizations connected to dependency organizations', function: organize };
         options.simplifiedOrgView = { name: 'simplifiedOrgView', text: 'Organizations connected by shared dependencies', function: simplifyOrganize };
         const optionsArray = Object.values(options);
 


### PR DESCRIPTION
Per Ian's idea, this pr adds a new subpage to the explore tab and moves the dependency graph to that page. The dependency graph also now has new features that make it easier to understand and interact with:
![image](https://user-images.githubusercontent.com/29114346/88227903-31d22a00-cc23-11ea-87d0-f25bc8e9d0e9.png)

Please let me know if I have made any errors in the editing of the html, I am not all that familiar with it.

Closes #368 in favor of working on other issues.