### PR TITLE
Fixed mouseover for tree

### DIFF
--- a/js/explore/force_dependencyGraph.js
+++ b/js/explore/force_dependencyGraph.js
@@ -213,6 +213,7 @@ function draw_force_graph(areaID, adjacentAreaID) {
             .height(10 * optionsArray.length - 1)
             .on('onchange', val => {
                 optionChanged(optionsArray[Math.round(val)]);
+                d3.select('.' + adjacentAreaID).select('g').remove();
             });
 
         chart.append('g')


### PR DESCRIPTION
I noticed an error that occurs when mousing over a node in the tree formed after clicking a node in the force graph. This error is caused when the user switched to a different graph after having generated the tree and then tries to hover over one of the trees nodes. Since the graph may no longer contain the node that corresponds to the node in the tree, the mouseover has a chance of passing in a null object to the BFS function, causing an error. This PR removes the possibility of such an error by removing the tree upon switching to a different graph. It also makes sense not to keep the tree around as it is no longer a reflection of the data.