### PR TITLE
Ease of use changes

### DIFF
--- a/js/explore/pack_hierarchy.js
+++ b/js/explore/pack_hierarchy.js
@@ -108,14 +108,6 @@ function draw_pack_hierarchy(areaID) {
             });
         }
 
-        /*.style('cursor', d => {
-                        if (d.children == undefined) {
-                            return 'default';
-                        } else {
-                            return 'pointer';
-                        }
-                    })*/
-
         updateLabel(focus.children);
         label.attr('fill-opacity', 1);
         

--- a/js/explore/pack_hierarchy.js
+++ b/js/explore/pack_hierarchy.js
@@ -39,7 +39,7 @@ function draw_pack_hierarchy(areaID) {
             .offset([-10, 0])
             .html(function(d) {
                 if (d.data.internal != undefined) {
-                    return `${d.data.name} : ${d.data.internal ? 'Internal' : 'External'}`;
+                    return `${d.data.username} : ${d.data.internal ? 'Internal' : 'External'}`;
                 } else {
                     return `${d.data.name}`
                 }
@@ -223,9 +223,8 @@ function draw_pack_hierarchy(areaID) {
                     data.children[indexOfOwner].children.push({ name: repo, children: [] });
                 }
                 let indexOfRepo = data.children[indexOfOwner].children.findIndex(d => d.name == repo);
-                // let username = obj1['data'][user]['name'] == null ? user : obj1['data'][user]['name']; Changes default name to full name
-                let username = user;
-                data.children[indexOfOwner].children[indexOfRepo].children.push({ name: username, value: 1, internal: true });
+                let username = obj1['data'][user]['name'] == null ? user : obj1['data'][user]['name'];
+                data.children[indexOfOwner].children[indexOfRepo].children.push({ name: user, value: 1, internal: true, username: username });
             }
         }
         for (var user in obj2['data']) {
@@ -244,7 +243,7 @@ function draw_pack_hierarchy(areaID) {
                 }
                 let indexOfRepo = data.children[indexOfOwner].children.findIndex(d => d.name == repo);
                 let username = obj2['data'][user]['name'] == null ? user : obj2['data'][user]['name'];
-                data.children[indexOfOwner].children[indexOfRepo].children.push({ name: username, value: 1, internal: false });
+                data.children[indexOfOwner].children[indexOfRepo].children.push({ name: user, value: 1, internal: false, username: username });
             }
         }
         

--- a/js/explore/pack_hierarchy.js
+++ b/js/explore/pack_hierarchy.js
@@ -100,24 +100,21 @@ function draw_pack_hierarchy(areaID) {
                     .attr('dy', '0.35em')
                     .attr('fill-opacity', 0)
                     .attr('radius', d => d.r * (maxRadius / d.parent.r))
-                    .style('cursor', d => {
-                        if (d.children == undefined) {
-                            return 'default';
-                        } else {
-                            return 'pointer';
-                        }
-                    })
-                    .text(d => {return d.data.name})
-                    .on('click', d => {
-                        if (d.children != undefined) {
-                            clicked(d);
-                        }
-                    });
+                    .attr('pointer-events', 'none')
+                    .text(d => {return d.data.name});
             
             label.nodes().forEach(node => {
                 node.setAttribute('font-size', Math.floor(10 * node.getAttribute('radius') * 2 / (node.getComputedTextLength() + 5)) + 'px')
             });
         }
+
+        /*.style('cursor', d => {
+                        if (d.children == undefined) {
+                            return 'default';
+                        } else {
+                            return 'pointer';
+                        }
+                    })*/
 
         updateLabel(focus.children);
         label.attr('fill-opacity', 1);
@@ -137,14 +134,19 @@ function draw_pack_hierarchy(areaID) {
             .attr('fill', d => colors[d.height + 1])
             .attr('r', d => d.r)
             .style('cursor', 'pointer')
-            .on('mouseover', tip.show)
+            .on('mouseover', d => {
+                if (d.depth >= focus.depth + 1) {
+                    tip.show(d);
+                }
+            })
             .on('mouseout', tip.hide);
 
         const childCircles = childNodes.append('circle')
             .attr('fill', d => d.data.internal ? colors[d.height + 1] : colors[d.depth + 3])
             .attr('r', d => d.r)
             .on('mouseover', tip.show)
-            .on('mouseout', tip.hide);
+            .on('mouseout', tip.hide)
+            .on('click', d => clicked(d.parent));
         
         parentCircles.on('click', clicked);
 
@@ -160,6 +162,10 @@ function draw_pack_hierarchy(areaID) {
 
         function zoom(d) {
             const focus_0 = focus;
+
+            while (d.depth > focus.depth + 1) {
+                d = d.parent
+            }
 
             focus = d;
 
@@ -217,7 +223,8 @@ function draw_pack_hierarchy(areaID) {
                     data.children[indexOfOwner].children.push({ name: repo, children: [] });
                 }
                 let indexOfRepo = data.children[indexOfOwner].children.findIndex(d => d.name == repo);
-                let username = obj1['data'][user]['name'] == null ? user : obj1['data'][user]['name'];
+                // let username = obj1['data'][user]['name'] == null ? user : obj1['data'][user]['name']; Changes default name to full name
+                let username = user;
                 data.children[indexOfOwner].children[indexOfRepo].children.push({ name: username, value: 1, internal: true });
             }
         }


### PR DESCRIPTION
Makes all of the changes (please let me know if I missed any) requested by @LRWeber in #398 to the zoomable circle packing graphic including:

- Default name changed to GitHub username for label but not tooltip
- Click through can now only go down at most one level, regardless of what is clicked allowing the user to click anything within a circle to go down a level
- Text now does not interact with the pointer allowing you to click through and hover over things under the text