### PR TITLE
Add on click event linking to repo pages

### DIFF
--- a/js/explore/line_repoActivityExplore.js
+++ b/js/explore/line_repoActivityExplore.js
@@ -280,8 +280,13 @@ function draw_line_repoActivity(areaID, repoNameWOwner) {
                         })
                         .attr('fill-opacity', 1)
                         .attr('d', d => arc(d))
+                        .style('cursor', 'pointer')
                         .on('mouseover', pieTip.show)
-                        .on('mouseout', pieTip.hide);
+                        .on('mouseout', pieTip.hide)
+                        .on('click', d => {
+                            const win = window.open(`https://software.llnl.gov/repo/#/${d.data.name.split('/')[0]}/${d.data.name.split('/')[1]}`);
+                            win.focus();
+                        });
 
             // Creates and formats the label of each slice
             const label = pieGroup

--- a/js/explore/line_repoActivityExplore.js
+++ b/js/explore/line_repoActivityExplore.js
@@ -284,7 +284,7 @@ function draw_line_repoActivity(areaID, repoNameWOwner) {
                         .on('mouseover', pieTip.show)
                         .on('mouseout', pieTip.hide)
                         .on('click', d => {
-                            const win = window.open(`https://software.llnl.gov/repo/#/${d.data.name.split('/')[0]}/${d.data.name.split('/')[1]}`);
+                            const win = window.open(`${window.location['origin']}/repo/#/${d.data.name.split('/')[0]}/${d.data.name.split('/')[1]}`);
                             win.focus();
                         });
 

--- a/js/explore/sunburst_licenses.js
+++ b/js/explore/sunburst_licenses.js
@@ -121,10 +121,10 @@ function draw_sunburst_licenses(areaID) {
         path.filter(d => !d.children)
             .style('cursor', 'pointer')
             .on('click', d => {
-                const win = window.open(`https://software.llnl.gov/repo/#/${d.data.name.split('/')[0]}/${d.data.name.split('/')[1]}`);
+                const win = window.open(`${window.location['origin']}/repo/#/${d.data.name.split('/')[0]}/${d.data.name.split('/')[1]}`);
                 win.focus();
             });
-            
+
         // Adds labels to wedges
         let label = centerGroup
             .append('g')

--- a/js/explore/sunburst_licenses.js
+++ b/js/explore/sunburst_licenses.js
@@ -118,6 +118,13 @@ function draw_sunburst_licenses(areaID) {
             .style('cursor', 'pointer')
             .on('click', clicked);
 
+        path.filter(d => !d.children)
+            .style('cursor', 'pointer')
+            .on('click', d => {
+                const win = window.open(`https://software.llnl.gov/repo/#/${d.data.name.split('/')[0]}/${d.data.name.split('/')[1]}`);
+                win.focus();
+            });
+            
         // Adds labels to wedges
         let label = centerGroup
             .append('g')


### PR DESCRIPTION
This PR adds an on click event to the license sunburst and the activity pie chart that links to the software.llnl.gov/repo/#/Owner/Repo subpage. Implemented at @IanLee1521 's request.