### PR TITLE
Document the DOI process

### DIFF
--- a/about/faq.md
+++ b/about/faq.md
@@ -104,6 +104,8 @@ After your project has been initially released on GitHub and you are ready to pr
 
 Another good practice is to provide user documentation. Read the Docs (RtD) is a common platform for user guides, tutorials, quick start instructions, and other forms of documentation. Our [.github repo](https://github.com/LLNL/.github) contains step-by-step instructions for setting up a RtD instance, a [template](https://github-main.readthedocs.io/en/latest/) you can start with, and links to various resources for tips and additional details.
 
+Submit your repo to [DOE CODE](https://www.osti.gov/doecode/faq#what-is) so others can find it when searching through DOE-funded projects. After your repo is included in DOE CODE, you may also want to add the digital object identifier (DOI) to the repo. See the [relevant section](https://software.llnl.gov/about/licenses/#digital-object-identifier-doi) of our LLNL Software Licensing page for more information.
+
 ### How do I include my repo in the LLNL organization and/or this website’s catalog?
 
 Repositories within the LLNL organization are owned and managed by LLNL. Please do not create personal repositories here.

--- a/about/licenses/index.md
+++ b/about/licenses/index.md
@@ -85,7 +85,7 @@ top-level `COPYRIGHT` file with a summary of license details. GitHub's
 and `LICENSE-*` files for an example of how to organize a project with
 two licenses.
 
-### Other considerations
+### Other Considerations
 
 In addition to the required files above, you should read the following
 sections and determine whether they apply to your code.
@@ -191,6 +191,27 @@ process that deters potential contributors.  Unless you feel that you
 need this level of assurance for your project, we recommend that you
 simply rely on the default inbound = outbound assumption.
 
+#### Digital Object Identifier (DOI)
+
+A digital object identifier (DOI) is a unique persistent identifier that 
+references a digital object and provides long-term access. You may have 
+noticed that journal articles carry DOIs. So, too, can open source software repositories.
+
+The U.S. Office of Scientific and Technical Information (OSTI) assigns DOIs 
+to software *after* your code has been submitted to [DOE CODE](https://www.osti.gov/doecode/faq#what-is). 
+See OSTI's [FAQ on DOIs](https://www.osti.gov/doecode/faq#what-is-a-doi) for 
+details about how DOIs work and why they are beneficial.
+
+OSTI is evaluating a notification workflow that would let a developer know 
+when a DOI has been assigned. Until then, you can find your repos's DOI *and* 
+add it to the repo by following these steps:
+
+1. Type in the name of your repo at [DOE CODE](https://www.osti.gov/doecode/), then select it.
+2. Look in the RESOURCE section for the DOI number.
+3. In the SAVE/SHARE section, click Export Metadata and download the YAML file.
+4. Include that file in your repo in one of two ways:
+- Create a [CITATION file](https://citation-file-format.github.io/)
+- Add it to the [README file](https://guides.github.com/activities/citable-code/)
 
 ### Have Questions?
 

--- a/about/licenses/index.md
+++ b/about/licenses/index.md
@@ -194,8 +194,8 @@ simply rely on the default inbound = outbound assumption.
 #### Digital Object Identifier (DOI)
 
 A digital object identifier (DOI) is a unique persistent identifier that 
-references a digital object and provides long-term access. You may have 
-noticed that journal articles carry DOIs. So, too, can open source software repositories.
+references a digital object and provides long-term access. Just as journal 
+articles carry DOIs, so too can open source software repositories.
 
 The U.S. Office of Scientific and Technical Information (OSTI) assigns DOIs 
 to software *after* your code has been submitted to [DOE CODE](https://www.osti.gov/doecode/faq#what-is). 


### PR DESCRIPTION
Added DOI info per OSTI & LLNL folks to the Licenses Guide page, then mentioned it and linked to it from FAQ. A repo's DOI is not exactly where the emailed instructions said it would be (looking at MFEM for example: https://www.osti.gov/doecode/biblio/34658), so the instructions in this PR reflect reality.