### PR TITLE
Modify display of date/tags on news posts

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -87,6 +87,7 @@
 }
 
 .flex-item h4 > small {
+    /* Display of news post date and tag */
     border-left: 1px solid #777;
     padding-left: 5px;
 }

--- a/news/archive.md
+++ b/news/archive.md
@@ -15,8 +15,10 @@ permalink: /news/archive/
                     <article class="news">
                         <h3>
                             {{post.title}}
-                            <small class="pull-right">{{ post.date | date: '%B %d, %Y' }} {% for categories in post.categories %} ({{ categories }}) {% endfor %}</small>
                         </h3>
+                        <h4>
+                            <small>{{ post.date | date: '%B %d, %Y' }} {% for categories in post.categories %} ({{ categories }}) {% endfor %}</small>
+                        </h4>
 
                         {{ post.content }}
                         

--- a/news/events.md
+++ b/news/events.md
@@ -10,8 +10,10 @@ permalink: /news/events/
     <article class="news">
      <h3>
         {{ page.title }}
-        <small class="pull-right">{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
-      </h3>
+    </h3>
+    <h4>
+        <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
+    </h4>
 
       {{ page.content }}
 

--- a/news/index.md
+++ b/news/index.md
@@ -9,8 +9,10 @@ permalink: /news/
   <article class="news">
     <h3>
       {{ page.title }}
-      <small class="pull-right">{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
     </h3>
+    <h4>
+      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
+    </h4>
 
     {{ page.content }}
 


### PR DESCRIPTION
1. Moved date/tags on news posts to flush left for more elegant text wrap around Twitter block
2. Changed date/tags display to a combo of H4 and <small> (i.e.., moved it out of the H3 news post title and removed class="pull-right")
3. Affects three pages: News, Events, Archive