### PR TITLE
Fixing issue from white text clone

### DIFF
--- a/js/explore/helpers.js
+++ b/js/explore/helpers.js
@@ -31,6 +31,7 @@ function drawDateLine(dateObj, label, includeDate, chart, x, y, height, valuelin
         .attr('id', label)
         .text(label)
         .clone(true).lower()
+        .attr('id', `${label}-clone`)
         .attr("stroke-linejoin", "round")
         .attr("stroke-width", 3)
         .attr("stroke", "white");

--- a/js/explore/line_repoActivityExplore.js
+++ b/js/explore/line_repoActivityExplore.js
@@ -214,6 +214,10 @@ function draw_line_repoActivity(areaID, repoNameWOwner) {
                         const y = d3.select('#Thanksgiving').attr('y');
                         return +y + 20;
                     });
+                    d3.select('#Thanksgiving-clone').attr('y', d => {
+                        const y = d3.select('#Thanksgiving-clone').attr('y');
+                        return +y + 20;
+                    });
                     drawPie({ name: String(d.date), children: d.breakdown });
                     chart.call(pieTip);
                 });


### PR DESCRIPTION
This PR fixes this issue:
![image](https://user-images.githubusercontent.com/29114346/91600371-b009a680-e91c-11ea-866d-a9c7df036f2a.png)
Which was caused by the clone having the same id as the text.
