### PR TITLE
Always show as many posts up to twenty

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -15,10 +15,22 @@ $('.filterBtnGroup button').on('click', function(filterContent) {
     $('.filterBtnGroup button').attr('disabled', false);
     $(this).attr('disabled', true);
     var tag = $(this).text();
-    $('.news').hide();
-    $('.' + $(this).attr('id')).fadeIn();
+    $('.all').hide();
+    var max = 0;
+    $('.all').each(d => {
+        max = d;
+    });
+    var j = 0;
+    for (var i = 0; i <= max; i++) {
+        var element = $(`.post${i}`);
+        if (element.attr('class').includes($(this).attr('id')) && j < 20) {
+            element.fadeIn();
+            j++;
+        }
+    }
     filterContent.preventDefault();
-})
+});
+document.getElementById('all').click();
 </script>
 
 {% include google_analytics.html %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -16,21 +16,10 @@ $('.filterBtnGroup button').on('click', function(filterContent) {
     $(this).attr('disabled', true);
     var tag = $(this).text();
     $('.all').hide();
-    var max = 0;
-    $('.all').each(d => {
-        max = d;
-    });
-    var j = 0;
-    for (var i = 0; i <= max; i++) {
-        var element = $(`.post${i}`);
-        if (element.attr('class').includes($(this).attr('id')) && j < 20) {
-            element.fadeIn();
-            j++;
-        }
-    }
+    $('.' + $(this).attr('id')).fadeIn();
     filterContent.preventDefault();
 });
-document.getElementById('all').click();
+document.getElementById('allB').click();
 </script>
 
 {% include google_analytics.html %}

--- a/news/archive.md
+++ b/news/archive.md
@@ -6,7 +6,7 @@ permalink: /news/archive/
 {% assign postsByYear = site.posts | group_by_exp:"page", "page.date | date: '%Y'" %}
 
 <div class="filterBtnGroup btn-group" role="group" style="margin-bottom: 30px;">
-    <button class="btn btn-default" id="news">All</button>
+    <button class="btn btn-default" id="allB">All</button>
     <button class="btn btn-default" id="event">Events</button>
     <button class="btn btn-default" id="event-report">Event Reports</button>
     <button class="btn btn-default" id="new-repo">New Repos</button>
@@ -23,7 +23,7 @@ permalink: /news/archive/
         <div>
             <div class="collapse in" id="{{year.name}}" >
                 {% for post in year.items %}
-                    <article class="news  {{post.categories | join: " " }}">
+                    <article class="news allB all {{post.categories | join: " " }}">
                         <h3>
                             {{post.title}}
                         </h3>

--- a/news/index.md
+++ b/news/index.md
@@ -6,7 +6,7 @@ permalink: /news/
 
 
   <div class="filterBtnGroup btn-group" role="group">
-    <button class="btn btn-default" id="all">All</button>
+    <button class="btn btn-default" id="allB">All</button>
     <button class="btn btn-default" id="event">Events</button>
     <button class="btn btn-default" id="event-report">Event Reports</button>
     <button class="btn btn-default" id="new-repo">New Repos</button>
@@ -16,8 +16,22 @@ permalink: /news/
     <button class="btn btn-default" id="this-website">Meta</button>
   </div>
 
+  {% assign cap = 20 %} {% comment %} maximum number of each type to store {% endcomment %}
+  {% capture shh %}
+    {% increment event %}
+    {% increment eventReport %}
+    {% increment newRepo %}
+    {% increment profile %}
+    {% increment release %}
+    {% increment story %}
+    {% increment meta %}
+  {% endcapture %}
   {% for page in site.posts %}
-  <article class="news all {{page.categories | join: " " }} post{% increment index %}">
+    {% if page.categories contains "event" and event <= cap %}
+      {% capture quiet %}
+        {% increment event %}
+      {% endcapture %}
+  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
     <h3>
       {{ page.title }}
     </h3>
@@ -28,6 +42,97 @@ permalink: /news/
     {{ page.content }}
 
   </article>
+    {% elsif page.categories contains "event-report" and eventReport <= cap %}
+      {% capture quiet %}
+        {% increment eventReport %}
+      {% endcapture %}
+  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
+    <h3>
+      {{ page.title }}
+    </h3>
+    <h4>
+      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
+    </h4>
+
+    {{ page.content }}
+
+  </article>
+    {% elsif page.categories contains "new-repo" and newRepo <= cap %}
+      {% capture quiet %}
+        {% increment newRepo %}
+      {% endcapture %}
+  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
+    <h3>
+      {{ page.title }}
+    </h3>
+    <h4>
+      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
+    </h4>
+
+    {{ page.content }}
+
+  </article>
+    {% elsif page.categories contains "profile" and profile <= cap %}
+      {% capture quiet %}
+        {% increment profile %}
+      {% endcapture %}
+  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
+    <h3>
+      {{ page.title }}
+    </h3>
+    <h4>
+      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
+    </h4>
+
+    {{ page.content }}
+
+  </article>
+    {% elsif page.categories contains "release" and release <= cap %}
+      {% capture quiet %}
+        {% increment release %}
+      {% endcapture %}
+  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
+    <h3>
+      {{ page.title }}
+    </h3>
+    <h4>
+      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
+    </h4>
+
+    {{ page.content }}
+
+  </article>
+    {% elsif page.categories contains "story" and story <= cap %}
+      {% capture quiet %}
+        {% increment story %}
+      {% endcapture %}
+  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
+    <h3>
+      {{ page.title }}
+    </h3>
+    <h4>
+      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
+    </h4>
+
+    {{ page.content }}
+
+  </article>
+    {% elsif page.categories contains "this-website" and meta <= cap %}
+      {% capture quiet %}
+        {% increment meta %}
+      {% endcapture %}
+  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
+    <h3>
+      {{ page.title }}
+    </h3>
+    <h4>
+      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
+    </h4>
+
+    {{ page.content }}
+
+  </article>
+    {% endif %}
   {% endfor %}
   
    <br />

--- a/news/index.md
+++ b/news/index.md
@@ -6,7 +6,7 @@ permalink: /news/
 
 
   <div class="filterBtnGroup btn-group" role="group">
-    <button class="btn btn-default" id="news">All</button>
+    <button class="btn btn-default" id="all">All</button>
     <button class="btn btn-default" id="event">Events</button>
     <button class="btn btn-default" id="event-report">Event Reports</button>
     <button class="btn btn-default" id="new-repo">New Repos</button>
@@ -16,8 +16,8 @@ permalink: /news/
     <button class="btn btn-default" id="this-website">Meta</button>
   </div>
 
-  {% for page in site.posts limit:15 %}
-  <article class="news {{page.categories | join: " " }}">
+  {% for page in site.posts %}
+  <article class="news all {{page.categories | join: " " }} post{% increment index %}">
     <h3>
       {{ page.title }}
     </h3>

--- a/news/index.md
+++ b/news/index.md
@@ -31,96 +31,33 @@ permalink: /news/
       {% capture quiet %}
         {% increment event %}
       {% endcapture %}
-  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
-    <h3>
-      {{ page.title }}
-    </h3>
-    <h4>
-      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
-    </h4>
-
-    {{ page.content }}
-
-  </article>
     {% elsif page.categories contains "event-report" and eventReport <= cap %}
       {% capture quiet %}
         {% increment eventReport %}
       {% endcapture %}
-  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
-    <h3>
-      {{ page.title }}
-    </h3>
-    <h4>
-      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
-    </h4>
-
-    {{ page.content }}
-
-  </article>
     {% elsif page.categories contains "new-repo" and newRepo <= cap %}
       {% capture quiet %}
         {% increment newRepo %}
       {% endcapture %}
-  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
-    <h3>
-      {{ page.title }}
-    </h3>
-    <h4>
-      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
-    </h4>
-
-    {{ page.content }}
-
-  </article>
     {% elsif page.categories contains "profile" and profile <= cap %}
       {% capture quiet %}
         {% increment profile %}
       {% endcapture %}
-  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
-    <h3>
-      {{ page.title }}
-    </h3>
-    <h4>
-      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
-    </h4>
-
-    {{ page.content }}
-
-  </article>
     {% elsif page.categories contains "release" and release <= cap %}
       {% capture quiet %}
         {% increment release %}
       {% endcapture %}
-  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
-    <h3>
-      {{ page.title }}
-    </h3>
-    <h4>
-      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
-    </h4>
-
-    {{ page.content }}
-
-  </article>
     {% elsif page.categories contains "story" and story <= cap %}
       {% capture quiet %}
         {% increment story %}
       {% endcapture %}
-  <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
-    <h3>
-      {{ page.title }}
-    </h3>
-    <h4>
-      <small>{{ page.date | date: '%B %d, %Y' }} {% for categories in page.categories %} ({{ categories }}) {% endfor %}</small>
-    </h4>
-
-    {{ page.content }}
-
-  </article>
     {% elsif page.categories contains "this-website" and meta <= cap %}
       {% capture quiet %}
         {% increment meta %}
       {% endcapture %}
+    {% else %}
+      {% continue %}
+    {% endif %}
   <article class="news all post{% increment index %} {% if index <= cap %}allB {% endif %}{{page.categories | join: " " }}">
     <h3>
       {{ page.title }}
@@ -132,12 +69,7 @@ permalink: /news/
     {{ page.content }}
 
   </article>
-    {% endif %}
   {% endfor %}
   
-   <br />
-                <a class="btn btn-primary btn-block news" href="/news/archive/" role="button">See all news in the archive</a>
-
-
- 
-
+  <br />
+  <a class="btn btn-primary btn-block news" href="/news/archive/" role="button">See all news in the archive</a>


### PR DESCRIPTION
This PR should mostly fix issue #446 by showing as as many posts are are available in a given category up to 20. Also, the all button now starts clicked.