### PR TITLE
Fix error on non-news pages that use script layout

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -19,7 +19,9 @@ $('.filterBtnGroup button').on('click', function(filterContent) {
     $('.' + $(this).attr('id')).fadeIn();
     filterContent.preventDefault();
 });
-document.getElementById('allB').click();
+if (document.getElementById('allB')){
+    document.getElementById('allB').click();
+}
 </script>
 
 {% include google_analytics.html %}


### PR DESCRIPTION
Currently, the code that I use to press the "All" button on the news page causes a harmless error on every page that uses the scripts layout. This error message does not cause any problems, but it would be good to get rid of it.