### PR TITLE
Fix "github" id error

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -49,8 +49,8 @@
             <p><a class="navbar-normal" href="/explore/popular-repos/">Popular Repositories</a></p>
           </div>
         </li>
-        <li id="github"><a href="https://github.com/llnl"><span class="fa fa-github fa-lg"></span></a></li>
-        <li id="github"><a href="https://twitter.com/LLNL_OpenSource"><span class="fa fa-twitter fa-lg"></span></a></li>
+        <li id="github-button"><a href="https://github.com/llnl"><span class="fa fa-github fa-lg"></span></a></li>
+        <li id="twitter-button"><a href="https://twitter.com/LLNL_OpenSource"><span class="fa fa-twitter fa-lg"></span></a></li>
       </ul>
     </div>
 

--- a/js/explore/dependencies/force_dependencyGraph.js
+++ b/js/explore/dependencies/force_dependencyGraph.js
@@ -605,7 +605,14 @@ function draw_force_graph(areaID, adjacentAreaID) {
                     .attr('r', 5)
                     .attr('class', 'inGraph')
                     .attr('language', '')
-                    .attr('id', d => d.id)
+                    .attr('id', d => {
+                        if (d.id === 'github') {
+                            d.id = 'GitHub';
+                            return 'GitHub';
+                        } else {
+                            return d.id;
+                        }
+                    })
                     .attr('searched', undefined)
                     .attr('fill-opacity', 1)
                     .attr('stroke-opacity', 1)
@@ -1017,8 +1024,6 @@ function searchForm(event) {
     });
 
     $('.inGraph').attr('searched', function(i, d) {
-        console.debug($(this).attr('id'));
-        console.debug($(this).attr('id').toUpperCase().includes(document.getElementById('search').value.toUpperCase()) || (($(this).attr('language') != null) && $(this).attr('language').toUpperCase().includes(document.getElementById('search').value.toUpperCase())));
         return $(this).attr('id').toUpperCase().includes(document.getElementById('search').value.toUpperCase()) || (($(this).attr('language') != null) && $(this).attr('language').toUpperCase().includes(document.getElementById('search').value.toUpperCase()));
     });
 }

--- a/js/explore/dependencies/force_dependencyGraph.js
+++ b/js/explore/dependencies/force_dependencyGraph.js
@@ -605,14 +605,7 @@ function draw_force_graph(areaID, adjacentAreaID) {
                     .attr('r', 5)
                     .attr('class', 'inGraph')
                     .attr('language', '')
-                    .attr('id', d => {
-                        if (d.id === 'github') {
-                            d.id = 'GitHub';
-                            return 'GitHub';
-                        } else {
-                            return d.id;
-                        }
-                    })
+                    .attr('id', d => d.id)
                     .attr('searched', undefined)
                     .attr('fill-opacity', 1)
                     .attr('stroke-opacity', 1)


### PR DESCRIPTION
There was an error caused by the fact that the github button had "github" as an ID. Since ID's need to be unique, this caused some of the functionality to fail. PR also removes some unneeded debug statements.