### PR TITLE
Add multimedia filter to news pages

### DIFF
--- a/news/archive.md
+++ b/news/archive.md
@@ -9,6 +9,7 @@ permalink: /news/archive/
     <button class="btn btn-default" id="allB">All</button>
     <button class="btn btn-default" id="event">Events</button>
     <button class="btn btn-default" id="event-report">Event Reports</button>
+    <button class="btn btn-default" id="multimedia">Multimedia</button>
     <button class="btn btn-default" id="new-repo">New Repos</button>
     <button class="btn btn-default" id="profile">Profiles</button>
     <button class="btn btn-default" id="release">Releases</button>

--- a/news/index.md
+++ b/news/index.md
@@ -9,6 +9,7 @@ permalink: /news/
     <button class="btn btn-default" id="allB">All</button>
     <button class="btn btn-default" id="event">Events</button>
     <button class="btn btn-default" id="event-report">Event Reports</button>
+    <button class="btn btn-default" id="multimedia">Multimedia</button>
     <button class="btn btn-default" id="new-repo">New Repos</button>
     <button class="btn btn-default" id="profile">Profiles</button>
     <button class="btn btn-default" id="release">Releases</button>


### PR DESCRIPTION
I realized the News & News Archive pages were missing the Multimedia button/filter. I followed what Aidan did in PR #437 on news/index.md and news/archive.md. It worked locally.