### PR TITLE
Link fixes to 9 news posts

### DIFF
--- a/_posts/2017-05-08-mfemexascale.md
+++ b/_posts/2017-05-08-mfemexascale.md
@@ -3,4 +3,4 @@ title: "MFEM: Accelerating Simulation Software with Graphics Processing Units"
 categories: story
 ---
 
-LLNL scientists are redesigning simulation software to leverage the capabilities of next-generation exascale computing. [Read more](https://computing.llnl.gov/newsroom/accelerating-simulation-software-graphics-processing-units) about MFEM's role in our transition to exascale technology.
+LLNL scientists are redesigning simulation software to leverage the capabilities of next-generation exascale computing. Read more about MFEM's role in our transition to exascale technology (article unpublished in 2020).

--- a/_posts/2018-02-26-macpatch.md
+++ b/_posts/2018-02-26-macpatch.md
@@ -3,4 +3,4 @@ title: "MacPatch Keeps Thousands of LLNL Computers Running Smoothly"
 categories: story
 ---
 
-Now in its third generation, LLNL-developed [MacPatch](https://computing.llnl.gov/newsroom/macpatch-keeps-thousands-llnl-computers-running-smoothly) handles software installation and patching for the Laboratory’s Mac computers. It's [open source](https://github.com/llnl/macpatch), of course!
+Now in its third generation, LLNL-developed [MacPatch](https://computing.llnl.gov/projects/macpatch) handles software installation and patching for the Laboratory’s Mac computers. It's [open source](https://github.com/llnl/macpatch), of course!

--- a/_posts/2018-09-20-devday.md
+++ b/_posts/2018-09-20-devday.md
@@ -3,7 +3,7 @@ title: "Second Annual Developer Day Continues to Build on Success"
 categories: story
 ---
 
-On August 15, LLNL hosted [Developer Day](https://computing.llnl.gov/newsroom/second-annual-developer-day-continues-build-success). The all-day event featured discussion panels, lightning talks, and deep dives intended to bring the LLNL developer community together. Many presentations featured open-source projects developed at the Lab, including:
+On August 15, LLNL hosted Developer Day. The all-day event featured discussion panels, lightning talks, and deep dives intended to bring the LLNL developer community together. Many presentations featured open-source projects developed at the Lab, including:
 
 - [ADAPT](https://github.com/LLNL/ADAPT)
 - [Caliper](https://github.com/LLNL/Caliper)

--- a/_posts/2018-10-27-sc18.md
+++ b/_posts/2018-10-27-sc18.md
@@ -9,4 +9,4 @@ LLNL staff are heading to Dallas, Texas, for the 30th annual Supercomputing Conf
 - Monday, November 12, 8:30am–5:00pm, Tutorial: [Managing HPC Software Complexity with Spack](https://sc18.supercomputing.org/presentation/?id=tut165&sess=sess252)
 - Tuesday, November 13, 12:15-1:15pm, BOF: [Spack Community](https://sc18.supercomputing.org/presentation/?id=bof173&sess=sess428) 
 
-Read more about [our past experiences and tips for first-timers](https://computing.llnl.gov/newsroom/looking-ahead-sc18). A complete list of LLNL-led sessions can be found on the [LLNL Computing website](https://computing.llnl.gov/sc18-event-calendar). All times are listed in Central Standard Time.
+Read more about our past experiences and tips for first-timers, and a complete list of LLNL-led sessions can be found on the LLNL Computing website (links unpublished in 2020). All times are listed in Central Standard Time.

--- a/_posts/2018-11-26-unify.md
+++ b/_posts/2018-11-26-unify.md
@@ -13,4 +13,3 @@ Like much of LLNL’s HPC performance improvement software, Unify is open source
 - [Unify Docs](https://unifyfs.readthedocs.io/en/latest/)
 - [Exascale Computing Project](https://exascale.llnl.gov/)
 - [CASC Newsletter, Volume 4](https://computing.llnl.gov/casc/newsletter/vol-4#exascale)
-- News article: [New ‘Unify’ File Systems Deliver Fast I/O Performance over Distributed Storage](https://computing.llnl.gov/newsroom/new-unify-file-systems-deliver-fast-io-performance-over-distributed-storage)

--- a/_posts/2019-02-25-unify-0.2.0.md
+++ b/_posts/2019-02-25-unify-0.2.0.md
@@ -10,4 +10,3 @@ Learn more:
 - [Unify Docs](https://unifyfs.readthedocs.io/en/latest/)
 - [Release notes](https://github.com/LLNL/UnifyFS/releases/tag/v0.2.0)
 - [Unify: Distributed Burst Buffer File System](https://computing.llnl.gov/projects/unify)
-- News article: [New ‘Unify’ File Systems Deliver Fast I/O Performance over Distributed Storage](https://computing.llnl.gov/newsroom/new-unify-file-systems-deliver-fast-io-performance-over-distributed-storage)

--- a/_posts/2019-07-08-macpatch-3.3.0.2.md
+++ b/_posts/2019-07-08-macpatch-3.3.0.2.md
@@ -8,4 +8,3 @@ MacPatch -- used at LLNL to manage 3,000+ computers -- simplifies the act of pat
 Learn more:
 - [Release notes](https://github.com/LLNL/MacPatch/releases/tag/3.3.0.2)
 - [GitHub repo](https://github.com/llnl/macpatch)
-- Article: [MacPatch Keeps Thousands of LLNL Computers Running Smoothly](https://computing.llnl.gov/newsroom/macpatch-keeps-thousands-llnl-computers-running-smoothly)

--- a/_posts/2019-10-03-unify-0.9.0.md
+++ b/_posts/2019-10-03-unify-0.9.0.md
@@ -10,4 +10,3 @@ Learn more:
 - [GitHub repo](https://github.com/LLNL/UnifyFS)
 - [Documentation](https://unifyfs.readthedocs.io/en/v0.9.0/)
 - [Unify: Distributed Burst Buffer File System](https://computing.llnl.gov/projects/unify)
-- News article: [New ‘Unify’ File Systems Deliver Fast I/O Performance over Distributed Storage](https://computing.llnl.gov/newsroom/new-unify-file-systems-deliver-fast-io-performance-over-distributed-storage)

--- a/_posts/2020-12-03-unify-0.9.1.md
+++ b/_posts/2020-12-03-unify-0.9.1.md
@@ -10,4 +10,3 @@ Learn more:
 - [GitHub repo](https://github.com/LLNL/UnifyFS)
 - [Documentation](https://unifyfs.readthedocs.io/en/latest/)
 - [Unify: Distributed Burst Buffer File System](https://computing.llnl.gov/projects/unify)
-- News article: [New ‘Unify’ File Systems Deliver Fast I/O Performance over Distributed Storage](https://computing.llnl.gov/newsroom/new-unify-file-systems-deliver-fast-io-performance-over-distributed-storage)


### PR DESCRIPTION
In preparation for the new redesign/overhaul of computing.llnl.gov, I unpublished all news on _that_ website dated before 1/1/19 (Comp web team is only keeping 2 years' worth of news). That action resulted in several broken links on this website. I have unlinked these or found alternate links. Affects 9 news posts only.