### PR TITLE
Remove justification on repo.description

### DIFF
--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -64,7 +64,7 @@
                                         <small><span alt="Primary Language" title="Primary Language"> {{ repo.language || '-' }} </span></small>
                                     </h4>
 
-                                    <p class="text-justify">{{ repo.description }}</p>
+                                    <p>{{ repo.description }}</p>
 
                                     <p class="stats text-center">
                                         <a href="{{ repo.gitUrl }}" alt="GitHub Page" title="GitHub Page">


### PR DESCRIPTION
The fully justified text in the "card" view of a repo's description was bothering me. It causes inconsistent spacing and looks weird on many repos. I removed the justification so repo descriptions display as left-justified (i.e., ragged right). Before & after screen shots attached. This does NOT affect the repo description on a repo's Explore page, nor does it affect the CSS of the `<blockquote>` which is how the description is wrapped on /repo.index.html.

BEFORE
![justified](https://user-images.githubusercontent.com/31740953/104366319-08a59e80-54ce-11eb-9719-992827e9904a.PNG)

AFTER
![ragged right](https://user-images.githubusercontent.com/31740953/104366339-0f341600-54ce-11eb-951f-76e3e2cc77be.PNG)
