### PR TITLE
add hatchet organization to input_lists.json

### DIFF
--- a/_explore/input_lists.json
+++ b/_explore/input_lists.json
@@ -7,6 +7,7 @@
         "flux-framework",
         "glvis",
         "gmlc-tdc",
+        "hatchet",
         "hypre-space",
         "llnl",
         "mfem",


### PR DESCRIPTION
This adds the new hatchet organization (https://github.com/hatchet) to the list of LLNL OSS organizations.

@bhatele, @slabasan: FYI.