### PR TITLE
Add P&G link to RADIUSS blurb

### DIFF
--- a/radiuss/index.html
+++ b/radiuss/index.html
@@ -5,7 +5,7 @@ layout: portal
 
 {% raw %}
 
-<p class="page-title">LLNL's RADIUSS project&mdash;Rapid Application Development via an Institutional Universal Software Stack&mdash; <br />aims to broaden usage across LLNL and the open source community of a set of libraries and tools <br />used for HPC scientific application development.</p>
+<p class="page-title">LLNL's RADIUSS project&mdash;Rapid Application Development via an Institutional Universal Software Stack&mdash; <br />aims to broaden usage across LLNL and the open source community of a set of libraries and tools <br />used for HPC scientific application development. Read more about our <a href="/radiuss/policies/">Policies & Guidelines</a>.</p>
 
 <section class="flex-container" id="categories">
     <div ng-repeat="category in catData" class="flex-category">


### PR DESCRIPTION
Didn't know what I didn't know... PR #508 added a gem file that solved my problem, and now the P&G page is linked from the main RADIUSS page.