### PR TITLE
Limit news archive to 4 years

### DIFF
--- a/news/archive.md
+++ b/news/archive.md
@@ -18,7 +18,7 @@ permalink: /news/archive/
 </div>
 
 <div>
-   {% for year in postsByYear %}
+   {% for year in postsByYear limit:4 %}
         <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#{{year.name}}" aria-expanded="true" aria-controls="{{year.name}}"> {{year.name}} <i class= "fa fa-caret-down"></i></button>
 
         <div>


### PR DESCRIPTION
The first post in the news archive is dated 1/6/16, which is now 6 years old. The archive doesn't need to retain that much outdated content, so I limited the archive to just 4 years (current + last 3). When #537 (containing the first news posts of 2022) is merged, the archive will display 2022-2019. 2018-2016 will no longer be displayed, but the posts still exist in the `_posts` folder in case we ever need to access them again. This might make the archive page load a little faster, too. I tested locally with both 2022-2019 and 2021-2018 posts to make sure it works if this PR is merged ahead of #537.