### PR TITLE
Fix "full catalog" link not loading the page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: homepage
 
 {% raw %}
 
-<p class="page-title">Welcome to the LLNL software portal—a hub for our open source projects. <br />Our <a ng-click="categoryHref('ALL SOFTWARE')" style="cursor: pointer">full catalog</a> is updated regularly as repositories are added or modified.</p>
+<p class="page-title">Welcome to the LLNL software portal—a hub for our open source projects. <br />Our <a ng-click="categoryHref('All Software')" style="cursor: pointer">full catalog</a> is updated regularly as repositories are added or modified.</p>
 
 <section class="flex-container" id="categories">
     <div ng-repeat="category in catData" class="flex-category dynamic" ng-click="categoryHref(category.title)">


### PR DESCRIPTION
Fixing a bug where the main page's "full catalog" link directs the browser to `https://software.llnl.gov/category/#/ALLSOFTWARE` instead of `https://software.llnl.gov/category/#/AllSoftware`, which results in the desired page not loading properly.