### PR TITLE
WIP: CSS updates

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,13 +3,13 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <link rel="shortcut icon" href="https://cdn.llnl.gov/onelab/0.1.1/images/favicon.ico">
+  <link rel="shortcut icon" href="/assets/images/OS-icon-color.png">
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" media="screen">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" media="screen">
 
-  <link rel="stylesheet" href="https://cdn.llnl.gov/onelab/0.1.1/css/onelab.css" media="screen">
   <link rel="stylesheet" href="/css/main.css" media="screen">
+  <link rel="stylesheet" href="https://cdn.llnl.gov/onelab/0.1.1/css/onelab.css" media="screen">
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@llnl_opensource" />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,7 @@
     <div id="siteNavbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav navbar-right navbar-collapse">
         <li id="radiuss"
-            {% if page.url == "/radiuss/" %} class="active-dropdown"
+            {% if page.url == "/radiuss/" %} class="active dropdown"
             {% else %} class="dropdown"
             {% endif %}><a class="navbar-normal" href="/radiuss/">RADIUSS</a>
           <div class="dropdown-content">
@@ -23,7 +23,7 @@
           </div>
         </li>
         <li id="news"
-            {% if page.url == "/news/" %} class="active-dropdown"
+            {% if page.url == "/news/" %} class="active dropdown"
             {% else %} class="dropdown"
             {% endif %}><a class="navbar-normal" href="/news/">News</a>
           <div class="dropdown-content">
@@ -31,7 +31,7 @@
           </div>
         </li>
         <li id="about"
-            {% if page.url == "/about/" %} class="active-dropdown"
+            {% if page.url == "/about/" %} class="active dropdown"
             {% else %} class="dropdown"
             {% endif %}><a class="navbar-normal" href="/about/">About</a>
           <div class="dropdown-content">
@@ -40,7 +40,7 @@
           </div>
         </li>
         <li id="explore"
-            {% if page.url == "/explore/" %} class="active-dropdown"
+            {% if page.url == "/explore/" %} class="active dropdown"
             {% else %} class="dropdown"
             {% endif %}><a class="navbar-normal" href="/explore/">Explore</a>
           <div class="dropdown-content">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,13 +9,13 @@
       </button>
 
       <p id="llnl-menu-tab" class="pull-left"><a href="https://www.llnl.gov"></a></p>
-      <a class="navbar-brand" href="/">{{ site.name }}</a>
+      <a class="navbar-brand" href="/"><b>{{ site.name }}</b></a>
     </div>
 
     <div id="siteNavbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav navbar-right navbar-collapse">
         <li id="radiuss"
-            {% if page.url == "/radiuss/" %} class="active dropdown"
+            {% if page.url == "/radiuss/" %} class="active-dropdown"
             {% else %} class="dropdown"
             {% endif %}><a class="navbar-normal" href="/radiuss/">RADIUSS</a>
           <div class="dropdown-content">
@@ -23,7 +23,7 @@
           </div>
         </li>
         <li id="news"
-            {% if page.url == "/news/" %} class="active dropdown"
+            {% if page.url == "/news/" %} class="active-dropdown"
             {% else %} class="dropdown"
             {% endif %}><a class="navbar-normal" href="/news/">News</a>
           <div class="dropdown-content">
@@ -31,7 +31,7 @@
           </div>
         </li>
         <li id="about"
-            {% if page.url == "/about/" %} class="active dropdown"
+            {% if page.url == "/about/" %} class="active-dropdown"
             {% else %} class="dropdown"
             {% endif %}><a class="navbar-normal" href="/about/">About</a>
           <div class="dropdown-content">
@@ -40,7 +40,7 @@
           </div>
         </li>
         <li id="explore"
-            {% if page.url == "/explore/" %} class="active dropdown"
+            {% if page.url == "/explore/" %} class="active-dropdown"
             {% else %} class="dropdown"
             {% endif %}><a class="navbar-normal" href="/explore/">Explore</a>
           <div class="dropdown-content">

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -39,7 +39,7 @@
                             <div class="title-container page-header">
                                 <img ng-src="{{ category.icon.path }}" style="width: 125px; height: 125px" alt="{{ category.icon.alt }}" title="{{ category.icon.alt }}" />
                                 <div class="title-description" style="width: 700px">
-                                    <h3>{{ category.title }}</h3>
+                                    <h2>{{ category.title }}</h2>
                                     <p>{{ category.description.short }}{{ category.description.long }}</p>
                                 </div>
                             </div>

--- a/css/main.css
+++ b/css/main.css
@@ -1,3 +1,11 @@
+/* General (ideal) color palette */
+
+/* blue links #005dab
+regular teal hover #009bab
+light teal accent #81D0D3
+text gray #555555
+light gray background #ddd */
+
 /* FlexBox configuration (category browse) */
 
 .flex-container {
@@ -143,8 +151,8 @@
     }
     #forkongithub a {
         pointer-events: all;
-        background: #555555;
-        color: #fff;
+        background: #ddd;
+        color: #005dab;
         text-decoration: none;
         font-family: arial, sans-serif;
         text-align: center;
@@ -164,8 +172,8 @@
         box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
     }
     #forkongithub a:hover {
-        background: #333333;
-        color: #fff;
+        background: #ddd;
+        color: #009bab;
     }
     #forkongithub a::before,
     #forkongithub a::after {
@@ -207,7 +215,7 @@ a:visited {
     text-decoration: none;
 }
 
-/* Buttons */
+/* Buttons (not news filters) */
 
 .btn {
     color: #005dab;
@@ -466,6 +474,8 @@ a:visited {
     }
 }
 
+/* Stickynav & tab = left-hand menu of catalog categories */
+
 .stickynav div {
     padding-left: 5px;
     padding-right: 15px;
@@ -493,8 +503,22 @@ a:visited {
 }
 
 .stickynav div:hover > a {
+    color: #009bab;
+}
+
+.tab {
     color: black;
 }
+.selected-tab {
+    background-color: #81D0D3;
+    color: white;
+}
+
+.selected-tab > a {
+    color: white;
+}
+
+/* Hamburger nav at various widths */
 
 .hamburger-nav div {
     width: 100%;
@@ -517,24 +541,12 @@ a:visited {
 }
 
 .hamburger-nav div:hover > a {
-    color: black;
+    color: #009bab;
 }
 
 .hamburger-nav div:hover {
     background-color: lightgrey;
     padding-left: 18px;
-}
-
-.tab {
-    color: black;
-}
-.selected-tab {
-    background-color: #81D0D3;
-    color: white;
-}
-
-.selected-tab > a {
-    color: white;
 }
 
 .hamburger-container span {

--- a/css/main.css
+++ b/css/main.css
@@ -78,7 +78,6 @@
 }
 
 .flex-item h4 > small {
-    /* Display of news post date and tag */
     border-left: 1px solid #777;
     padding-left: 5px;
 }
@@ -144,7 +143,7 @@
     }
     #forkongithub a {
         pointer-events: all;
-        background: #555;
+        background: #555555;
         color: #fff;
         text-decoration: none;
         font-family: arial, sans-serif;
@@ -165,7 +164,7 @@
         box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.2);
     }
     #forkongithub a:hover {
-        background: #333;
+        background: #333333;
         color: #fff;
     }
     #forkongithub a::before,
@@ -198,6 +197,14 @@ a:visited {
     color: #009bab;
     text-decoration: none;
     font-weight: bold;
+}
+
+/* News post date and tag */
+
+.static-text h4 > small {
+    border-left: 1px;
+    color: #555555;
+    text-decoration: none;
 }
 
 /* Buttons */

--- a/css/main.css
+++ b/css/main.css
@@ -236,18 +236,20 @@ a:visited {
     text-decoration: none;
 }
 
-/* Buttons (not news filters) */
+/* Buttons */
 
 .btn {
     color: #005dab;
     text-decoration: none;
     font-weight: bold;
+    outline: none;
 }
 
-.btn a:hover {
+.btn:hover {
     color: #009bab;
     text-decoration: none;
     font-weight: bold;
+    outline: none;
 }
 
 /* Site title & home link in navigation bar */

--- a/css/main.css
+++ b/css/main.css
@@ -207,6 +207,27 @@ a:visited {
     font-weight: bold;
 }
 
+/* Centered intro paragraphs on home & RADIUSS catalog */
+
+.title-para {
+    padding-top: 30px;
+    padding-bottom: 10px;
+    text-align: center;
+    font-size: 22px;
+}
+
+.title-para a {
+    color: #005dab;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.title-para a:hover {
+    color: #009bab;
+    text-decoration: none;
+    font-weight: bold;
+}
+
 /* News post date and tag */
 
 .static-text h4 > small {
@@ -249,6 +270,13 @@ a:visited {
 .navbar {
     margin-bottom: 0;
     color: #005dab;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.navbar:hover {
+    margin-bottom: 0;
+    color: #009bab;
     text-decoration: none;
     font-weight: bold;
 }
@@ -518,7 +546,7 @@ a:visited {
     color: white;
 }
 
-/* Hamburger nav at various widths */
+/* Hamburger nav for catalog categories at various widths */
 
 .hamburger-nav div {
     width: 100%;
@@ -563,7 +591,7 @@ a:visited {
 
 .hamburger-container span:hover {
     cursor: pointer;
-    color: black;
+    color: #009bab;
 }
 
 .hamburger-nav {

--- a/css/main.css
+++ b/css/main.css
@@ -1,29 +1,4 @@
-.static-text a,
-a:visited {
-    color: #005dab;
-    text-decoration: underline;
-}
-
-.static-text a:hover {
-    color: #009bab;
-    text-decoration: underline;
-}
-
-/* Buttons */
-
-.btn {
-    color: #005dab;
-    text-decoration: none;
-    font-weight: bold;
-}
-
-.btn a:hover {
-    color: #009bab;
-    text-decoration: none;
-    font-weight: bold;
-}
-
-/* FlexBox configuration */
+/* FlexBox configuration (category browse) */
 
 .flex-container {
     align-items: stretch;
@@ -31,6 +6,7 @@ a:visited {
     display: flex;
     flex-flow: row wrap;
     justify-content: center;
+    text-decoration: none;
 }
 
 .flex-container-category {
@@ -69,7 +45,7 @@ a:visited {
 }
 
 .flex-item:hover {
-    border: 1px solid steelblue;
+    border: 1px #81D0D3;
     box-shadow: 3px 3px #ddd;
     cursor: pointer;
 }
@@ -209,48 +185,96 @@ a:visited {
     }
 }
 
-/* --- */
+/* Links in text on non-category pages */
+
+.static-text a,
+a:visited {
+    color: #005dab;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.static-text a:hover {
+    color: #009bab;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+/* Buttons */
+
+.btn {
+    color: #005dab;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.btn a:hover {
+    color: #009bab;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+/* Site title & home link in navigation bar */
+
 .navbar-header a.navbar-brand {
     color: #005dab;
-    font-weight: bold;
     text-decoration: none;
+    font-weight: bold;
+}
+
+.navbar-header a.navbar-brand:hover {
+    color: #009bab;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+/* The rest of the navigation bar */
+/* Top-level link color set by OneLab CSS, not here */
+
+.navbar {
+    margin-bottom: 0;
+    color: #005dab;
+    text-decoration: none;
+    font-weight: bold;
 }
 
 .navbar a.navbar-normal {
     color: #005dab;
     text-decoration: none;
+    font-weight: bold;
 }
 
 .navbar a.navbar-normal:hover {
     color: #009bab;
     text-decoration: none;
+    font-weight: bold;
 }
 
-.navbar {
-    margin-bottom: 0;
-    text-decoration: none;
-}
-
-/* Dropdown */
+/* Dropdown menu */
 
 .dropdown-content {
     display: none;
     position: absolute;
     background-color: #f8f8f8;
+    color: #005dab;
     min-width: 160px;
     padding: 5px;
     text-decoration: none;
+    font-weight: bold;
 }
 
 @media (max-width: 768px) {
     .dropdown-content {
+        color: #005dab;
         visibility: hidden;
         text-decoration: none;
     }
 }
 
 .dropdown:hover .dropdown-content {
+    color: #009bab;
     display: block;
+    font-weight: bold;
 }
 
 @media (max-width: 767px) {
@@ -278,7 +302,7 @@ a:visited {
 }
 
 .dynamic:hover {
-    border: 1px solid steelblue;
+    border: 1px solid #81D0D3;
     box-shadow: 3px 3px #ddd;
     cursor: pointer;
 }
@@ -312,7 +336,7 @@ a:visited {
 
 .flex-category a:hover {
     /* Don't decorate links in repo items */
-    color: #777;
+    color: #81D0D3;
     text-decoration: none;
 }
 
@@ -498,7 +522,7 @@ a:visited {
     color: black;
 }
 .selected-tab {
-    background-color: steelblue;
+    background-color: #81D0D3;
     color: white;
 }
 

--- a/explore/index.html
+++ b/explore/index.html
@@ -5,7 +5,7 @@ layout: default
 
 {% raw %}
 
-<link rel="stylesheet" type="text/css" href="../css/graphstyle.css" />
+<link rel="stylesheet" type="text/css" href="/css/graphstyle.css" />
 
 <h2 class="page-header text-center">
     LLNL GitHub Visualizations

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: homepage
 
 {% raw %}
 
-<p class="page-title">Welcome to the LLNL software portal—a hub for our open source projects. <br />Our <a ng-click="categoryHref('All Software')" style="cursor: pointer">full catalog</a> is updated regularly as repositories are added or modified.</p>
+<p class="page-title">Welcome to the LLNL software portal—a hub for our open source projects. <br />Our <a href="/category/#/AllSoftware">full catalog</a> is updated regularly as repositories are added or modified.</p>
 
 <section class="flex-container" id="categories">
     <div ng-repeat="category in catData" class="flex-category dynamic" ng-click="categoryHref(category.title)">
@@ -34,7 +34,7 @@ layout: homepage
                 </span>
 
                 <span>
-                    <a ng-click="repoHref(repo.nameWithOwner); $event.stopPropagation();" alt="Rpo Info" title="Repo Info">
+                    <a ng-click="repoHref(repo.nameWithOwner); $event.stopPropagation();" alt="Repo Info" title="Repo Info">
                         <span class="fa fa-info-circle"></span>
                     </a>
                 </span>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ layout: homepage
 
 {% raw %}
 
-<p class="page-title">Welcome to the LLNL software portal—a hub for our open source projects. <br />Our <a href="/category/#/AllSoftware">full catalog</a> is updated regularly as repositories are added or modified.</p>
+<p class="title-para">Welcome to the LLNL software portal—a hub for our open source projects. <br />Our <a href="/category/#/AllSoftware">full catalog</a> is updated regularly as repositories are added or modified.</p>
 
 <section class="flex-container" id="categories">
     <div ng-repeat="category in catData" class="flex-category dynamic" ng-click="categoryHref(category.title)">

--- a/news/archive.md
+++ b/news/archive.md
@@ -6,20 +6,20 @@ permalink: /news/archive/
 {% assign postsByYear = site.posts | group_by_exp:"page", "page.date | date: '%Y'" %}
 
 <div class="filterBtnGroup btn-group" role="group" style="margin-bottom: 30px;">
-    <button type="button" class="btn btn-outline-primary" id="allB">All</button>
-    <button type="button" class="btn btn-outline-primary" id="event">Events</button>
-    <button type="button" class="btn btn-outline-primary" id="event-report">Event Reports</button>
-    <button type="button" class="btn btn-outline-primary" id="multimedia">Multimedia</button>
-    <button type="button" class="btn btn-outline-primary" id="new-repo">New Repos</button>
-    <button type="button" class="btn btn-outline-primary" id="profile">Profiles</button>
-    <button type="button" class="btn btn-outline-primary" id="release">Releases</button>
-    <button type="button" class="btn btn-outline-primary" id="story">Stories</button>
-    <button type="button" class="btn btn-outline-primary" id="this-website">Meta</button>
+    <button type="button" class="btn" id="allB">All</button>
+    <button type="button" class="btn" id="event">Events</button>
+    <button type="button" class="btn" id="event-report">Event Reports</button>
+    <button type="button" class="btn" id="multimedia">Multimedia</button>
+    <button type="button" class="btn" id="new-repo">New Repos</button>
+    <button type="button" class="btn" id="profile">Profiles</button>
+    <button type="button" class="btn" id="release">Releases</button>
+    <button type="button" class="btn" id="story">Stories</button>
+    <button type="button" class="btn" id="this-website">Meta</button>
   </div>
 
 <div>
    {% for year in postsByYear limit:4 %}
-        <button class="btn btn-outline-primary" type="button" data-toggle="collapse" data-target="#{{year.name}}" aria-expanded="true" aria-controls="{{year.name}}"> {{year.name}} <i class= "fa fa-caret-down"></i></button>
+        <button type="button" class="btn" data-toggle="collapse" data-target="#{{year.name}}" aria-expanded="true" aria-controls="{{year.name}}"> {{year.name}} <i class= "fa fa-caret-down"></i></button>
 
         <div>
             <div class="collapse in" id="{{year.name}}" >

--- a/news/index.md
+++ b/news/index.md
@@ -4,16 +4,16 @@ layout: news
 permalink: /news/
 ---
 
-  <div class="filterBtnGroup btn-group" role="group">
-    <button type="button" class="btn btn-outline-primary" id="allB">All</button>
-    <button type="button" class="btn btn-outline-primary" id="event">Events</button>
-    <button type="button" class="btn btn-outline-primary" id="event-report">Event Reports</button>
-    <button type="button" class="btn btn-outline-primary" id="multimedia">Multimedia</button>
-    <button type="button" class="btn btn-outline-primary" id="new-repo">New Repos</button>
-    <button type="button" class="btn btn-outline-primary" id="profile">Profiles</button>
-    <button type="button" class="btn btn-outline-primary" id="release">Releases</button>
-    <button type="button" class="btn btn-outline-primary" id="story">Stories</button>
-    <button type="button" class="btn btn-outline-primary" id="this-website">Meta</button>
+<div class="filterBtnGroup btn-group" role="group" style="margin-bottom: 30px;">
+    <button type="button" class="btn" id="allB">All</button>
+    <button type="button" class="btn" id="event">Events</button>
+    <button type="button" class="btn" id="event-report">Event Reports</button>
+    <button type="button" class="btn" id="multimedia">Multimedia</button>
+    <button type="button" class="btn" id="new-repo">New Repos</button>
+    <button type="button" class="btn" id="profile">Profiles</button>
+    <button type="button" class="btn" id="release">Releases</button>
+    <button type="button" class="btn" id="story">Stories</button>
+    <button type="button" class="btn" id="this-website">Meta</button>
   </div>
 
   {% assign cap = 20 %} {% comment %} maximum number of each type to store {% endcomment %}
@@ -77,4 +77,4 @@ permalink: /news/
   {% endfor %}
   
   <br />
-  <button type="button" class="btn btn-outline-primary btn-lg btn-block"><a href="/news/archive/">See all news in the archive</a></button>
+  <button type="button" class="btn btn-lg btn-block"><a href="/news/archive/">See all news in the archive</a></button>

--- a/radiuss/index.html
+++ b/radiuss/index.html
@@ -5,7 +5,7 @@ layout: portal
 
 {% raw %}
 
-<p class="page-title">LLNL's RADIUSS project&mdash;Rapid Application Development via an Institutional Universal Software Stack&mdash; <br />aims to broaden usage across LLNL and the open source community of a set of libraries and tools <br />used for HPC scientific application development. Read more about our <a href="/radiuss/policies/">Policies & Guidelines</a>.</p>
+<p class="title-para">LLNL's RADIUSS project&mdash;Rapid Application Development via an Institutional Universal Software Stack&mdash; <br />aims to broaden usage across LLNL and the open source community of a set of libraries and tools <br />used for HPC scientific application development. Read more about our <a href="/radiuss/policies/">Policies & Guidelines</a>.</p>
 
 <section class="flex-container" id="categories">
     <div ng-repeat="category in catData" class="flex-category">

--- a/repo/index.html
+++ b/repo/index.html
@@ -5,8 +5,9 @@ layout: repo
 
 {% raw %}
 
-<link rel="stylesheet" type="text/css" href="../css/repostyle.css" />
-<link rel="stylesheet" type="text/css" href="../css/graphstyle.css" />
+<link rel="stylesheet" type="text/css" href="/css/repostyle.css" />
+<link rel="stylesheet" type="text/css" href="/css/graphstyle.css" />
+<link rel="stylesheet" type="text/css" href="/css/main.css" />
 
 <div id="mainContent">
     <h1 class="page-header text-center">


### PR DESCRIPTION
For accessibility, link text needs two of the three styles: bold, underline, sufficient color contrast from static text. I changed underline to bold *and* changed the rollover/hover color to aqua (from the logo) to contrast more with the blue. I also changed the catalog left-hand menu category active state to white text on aqua, as well as the rollover state of the repo cards/boxes. Several different blues were used around the site, so this alleviates that somewhat and aligns the site's accent colors with the LLNL Open Source logo.

Update 2/1/22: Two places where I have yet to override the OneLab template with the new link style: (1) top-level menu items (the dropdowns are blue/aqua, at least). (2) Active-state news/archive buttons.

This is not a perfect implementation of what I was trying to do, but it is more accessible that it was re: government website standards.

Combined with yesterday's https://github.com/LLNL/llnl.github.io/pull/541, this PR closes https://github.com/LLNL/llnl.github.io/issues/319 and https://github.com/LLNL/llnl.github.io/issues/318. We have a separate issue (https://github.com/LLNL/llnl.github.io/issues/283) for updating the site theme to the generation beyond the OneLab template. 