### PR TITLE
Apply style to hypre

### DIFF
--- a/_posts/2019-07-10-hypre-2.17.md
+++ b/_posts/2019-07-10-hypre-2.17.md
@@ -1,9 +1,9 @@
 ---
-title: "Hypre 2.17 Released"
+title: "hypre 2.17 Released"
 categories: release
 ---
 
-Hypre is a library of high-performance preconditioners and solvers featuring multigrid methods for the solution of large, sparse linear systems of equations on massively parallel computers. [Version 2.17](https://github.com/hypre-space/hypre/releases/tag/v2.17.0) changes the license from GNU to [Apache 2.0](https://github.com/hypre-space/hypre/blob/master/LICENSE-APACHE)/[MIT](https://github.com/hypre-space/hypre/blob/master/LICENSE-MIT).
+*hypre* is a library of high-performance preconditioners and solvers featuring multigrid methods for the solution of large, sparse linear systems of equations on massively parallel computers. [Version 2.17](https://github.com/hypre-space/hypre/releases/tag/v2.17.0) changes the license from GNU to [Apache 2.0](https://github.com/hypre-space/hypre/blob/master/LICENSE-APACHE)/[MIT](https://github.com/hypre-space/hypre/blob/master/LICENSE-MIT).
 
 Learn more:
 - [GitHub repository](https://github.com/hypre-space/hypre)

--- a/_posts/2021-04-09-falgout-siam.md
+++ b/_posts/2021-04-09-falgout-siam.md
@@ -3,4 +3,4 @@ title: "LLNL’s Rob Falgout Named to 2021 Class of SIAM Fellows"
 categories: profile story
 ---
 
-The Society for Industrial and Applied Mathematics (SIAM) has announced its 2021 Class of Fellows, including LLNL computational mathematician Rob Falgout. Falgout is best known for his development of multigrid methods and for [Hypre](https://github.com/hypre-space/hypre), one of the world’s most popular parallel multigrid codes. LLNL News has the fully story about [this honor](https://www.llnl.gov/news/llnls-falgout-named-2021-class-siam-fellows).
+The Society for Industrial and Applied Mathematics (SIAM) has announced its 2021 Class of Fellows, including LLNL computational mathematician Rob Falgout. Falgout is best known for his development of multigrid methods and for *[hypre](https://github.com/hypre-space/hypre)*, one of the world’s most popular parallel multigrid codes. LLNL News has the fully story about [this honor](https://www.llnl.gov/news/llnls-falgout-named-2021-class-siam-fellows).

--- a/_posts/2021-08-01-mfem-4.3.md
+++ b/_posts/2021-08-01-mfem-4.3.md
@@ -8,7 +8,7 @@ categories: release
 - Variable order spaces, serial p- and hp-refinement
 - Low order refined discretizations, solvers and transfer
 - Preconditioners for advection-dominated systems
-- Support for GPU solvers from [hypre](https://github.com/hypre-space/hypre) and [PETSc](https://github.com/CEED/PETSc)
+- Support for GPU solvers from *[hypre](https://github.com/hypre-space/hypre)* and [PETSc](https://github.com/CEED/PETSc)
 - GPU-accelerated mesh optimization algorithms
 - Explicit vectorization for Fujitsu's A64FX ARM microprocessor
 - Support for high-order Lagrange meshes in VTK format


### PR DESCRIPTION
Rob's preference for his repo's name is italic lowercase _hypre_, or all-caps HYPRE when styling cannot be applied. I updated a few news posts accordingly. I only touched posts dated 2019 and later, as we're not displaying older news.