### PR TITLE
Fix broken categories on home

### DIFF
--- a/js/category-info.js
+++ b/js/category-info.js
@@ -91,7 +91,7 @@ app.controller('gitHubDataController', function($scope, $http, $window, Category
                 //function to generate hash url for each category
                 $scope.categoryHref = function(nametag) {
                     var result = nametag.replace(/ /g, '');
-                    $window.location.href = '../category#' + result;
+                    $window.location.href = '../explore#' + result;
                 };
             });
         });

--- a/pages/explore/category_info.json
+++ b/pages/explore/category_info.json
@@ -2,6 +2,7 @@
     "data": {
         "Build Tools": {
             "title": "Build Tools",
+            "hash": "BuildTools", 
             "icon": {
                 "path": "/assets/images/build-tools.svg",
                 "alt": "Build Tools"
@@ -16,6 +17,7 @@
         },
         "Math & Physics Libraries": {
             "title": "Math & Physics Libraries",
+            "hash": "Math&PhysicsLibraries",
             "icon": {
                 "path": "/assets/images/math.svg",
                 "alt": "Math & Physics Libraries"
@@ -30,6 +32,7 @@
         },
         "Data Management & Viz": {
             "title": "Data Management & Viz",
+            "hash": "DataManagement&Viz",
             "icon": {
                 "path": "/assets/images/data-manage.svg",
                 "alt": "Data Management & Visualization"
@@ -45,6 +48,7 @@
         },
         "Applications": {
             "title": "Applications",
+            "hash": "Applications",
             "icon": {
                 "path": "/assets/images/application.svg",
                 "alt": "Applications"
@@ -59,6 +63,7 @@
         },
         "Proxy Applications": {
             "title": "Proxy Applications",
+            "hash": "ProxyApplications",
             "icon": {
                 "path": "/assets/images/prox-app.svg",
                 "alt": "Proxy Applications"
@@ -73,6 +78,7 @@
         },
         "System Software": {
             "title": "System Software",
+            "hash": "SystemSoftware",
             "icon": {
                 "path": "/assets/images/system-software.svg",
                 "alt": "System Software"
@@ -87,6 +93,7 @@
         },
         "Portable Execution & Memory Mmgt": {
             "title": "Portable Execution & Memory Mmgt",
+            "hash": "PortableExecution&MemoryMmgt",
             "icon": {
                 "path": "/assets/images/portable.svg",
                 "alt": "Portable Execution & Memory Management"
@@ -102,6 +109,7 @@
         },
         "Performance & Workflow": {
             "title": "Performance & Workflow",
+            "hash": "Performance&Workflow",
             "icon": {
                 "path": "/assets/images/performance.svg",
                 "alt": "Performance & Workflow"
@@ -117,6 +125,7 @@
         },
         "File Systems": {
             "title": "File Systems",
+            "hash": "FileSystems",
             "icon": {
                 "path": "/assets/images/file-systems.svg",
                 "alt": "File Systems"
@@ -131,6 +140,7 @@
         },
         "App Infrastructure": {
             "title": "App Infrastructure",
+            "hash": "AppInfrastructure",
             "icon": {
                 "path": "/assets/images/app-infrastructure.svg",
                 "alt": "App Infrastructure"
@@ -145,6 +155,7 @@
         },
         "RADIUSS": {
             "title": "RADIUSS",
+            "hash": "RADIUSS",
             "icon": {
                 "path": "/assets/images/radiuss.svg",
                 "alt": "RADIUSS logo"

--- a/pages/explore/category_info.json
+++ b/pages/explore/category_info.json
@@ -1,5 +1,35 @@
 {
     "data": {
+        "App Infrastructure": {
+            "title": "App Infrastructure",
+            "hash": "AppInfrastructure",
+            "icon": {
+                "path": "/assets/images/app-infrastructure.svg",
+                "alt": "App Infrastructure"
+            },
+            "description": {
+                "short": "Browse tools for basic functionality common in HPC codes",
+                "long": ""
+            },
+            "topics":[
+                "app-infrastructure"
+            ]
+        },
+        "Applications": {
+            "title": "Applications",
+            "hash": "Applications",
+            "icon": {
+                "path": "/assets/images/application.svg",
+                "alt": "Applications"
+            },
+            "description": {
+                "short": "Browse scientific simulation codes and IT management tools",
+                "long": ""
+            },
+            "topics": [
+                "application"
+            ]
+        },
         "Build Tools": {
             "title": "Build Tools",
             "hash": "BuildTools", 
@@ -13,21 +43,6 @@
             },
             "topics": [
                 "build-tools"
-            ]
-        },
-        "Math & Physics Libraries": {
-            "title": "Math & Physics Libraries",
-            "hash": "Math&PhysicsLibraries",
-            "icon": {
-                "path": "/assets/images/math.svg",
-                "alt": "Math & Physics Libraries"
-            },
-            "description": {
-                "short": "Optimize solvers, higher order methods, and AMR frameworks",
-                "long": ""
-            },
-            "topics": [
-                "math-physics"
             ]
         },
         "Data Management & Viz": {
@@ -46,65 +61,34 @@
                 "data-viz"
             ]
         },
-        "Applications": {
-            "title": "Applications",
-            "hash": "Applications",
+        "File Systems": {
+            "title": "File Systems",
+            "hash": "FileSystems",
             "icon": {
-                "path": "/assets/images/application.svg",
-                "alt": "Applications"
+                "path": "/assets/images/file-systems.svg",
+                "alt": "File Systems"
             },
             "description": {
-                "short": "Browse scientific simulation codes and IT management tools",
+                "short": "Configure data storage and retrieval for more efficient workloads",
                 "long": ""
             },
             "topics": [
-                "application"
+                "file-system"
             ]
         },
-        "Proxy Applications": {
-            "title": "Proxy Applications",
-            "hash": "ProxyApplications",
+        "Math & Physics Libraries": {
+            "title": "Math & Physics Libraries",
+            "hash": "Math&PhysicsLibraries",
             "icon": {
-                "path": "/assets/images/prox-app.svg",
-                "alt": "Proxy Applications"
+                "path": "/assets/images/math.svg",
+                "alt": "Math & Physics Libraries"
             },
             "description": {
-                "short": "Prepare for testing and porting applications",
+                "short": "Optimize solvers, higher order methods, and AMR frameworks",
                 "long": ""
             },
             "topics": [
-                "proxy-application"
-            ]
-        },
-        "System Software": {
-            "title": "System Software",
-            "hash": "SystemSoftware",
-            "icon": {
-                "path": "/assets/images/system-software.svg",
-                "alt": "System Software"
-            },
-            "description": {
-                "short": "Manage laptop and desktop computer systems, HPC clusters, and parallel environments",
-                "long": ""
-            },
-            "topics": [
-                "system-software"
-            ]
-        },
-        "Portable Execution & Memory Mmgt": {
-            "title": "Portable Execution & Memory Mmgt",
-            "hash": "PortableExecution&MemoryMmgt",
-            "icon": {
-                "path": "/assets/images/portable.svg",
-                "alt": "Portable Execution & Memory Management"
-            },
-            "description": {
-                "short": "Automate data motion and memory allocation on advanced architectures",
-                "long": ""
-            },
-            "topics": [
-                "portability",
-                "memory-management"
+                "math-physics"
             ]
         },
         "Performance & Workflow": {
@@ -123,34 +107,35 @@
                 "workflows"
             ]
         },
-        "File Systems": {
-            "title": "File Systems",
-            "hash": "FileSystems",
+        "Portable Execution & Memory Mmgt": {
+            "title": "Portable Execution & Memory Mmgt",
+            "hash": "PortableExecution&MemoryMmgt",
             "icon": {
-                "path": "/assets/images/file-systems.svg",
-                "alt": "File Systems"
+                "path": "/assets/images/portable.svg",
+                "alt": "Portable Execution & Memory Management"
             },
             "description": {
-                "short": "Configure data storage and retrieval for more efficient workloads",
+                "short": "Automate data motion and memory allocation on advanced architectures",
                 "long": ""
             },
             "topics": [
-                "file-system"
+                "portability",
+                "memory-management"
             ]
         },
-        "App Infrastructure": {
-            "title": "App Infrastructure",
-            "hash": "AppInfrastructure",
+        "Proxy Applications": {
+            "title": "Proxy Applications",
+            "hash": "ProxyApplications",
             "icon": {
-                "path": "/assets/images/app-infrastructure.svg",
-                "alt": "App Infrastructure"
+                "path": "/assets/images/prox-app.svg",
+                "alt": "Proxy Applications"
             },
             "description": {
-                "short": "Browse tools for basic functionality common in HPC codes",
+                "short": "Prepare for testing and porting applications",
                 "long": ""
             },
-            "topics":[
-                "app-infrastructure"
+            "topics": [
+                "proxy-application"
             ]
         },
         "RADIUSS": {
@@ -167,6 +152,21 @@
                 "topics":[
                 "radiuss"
             ]            
+        },
+        "System Software": {
+            "title": "System Software",
+            "hash": "SystemSoftware",
+            "icon": {
+                "path": "/assets/images/system-software.svg",
+                "alt": "System Software"
+            },
+            "description": {
+                "short": "Manage laptop and desktop computer systems, HPC clusters, and parallel environments",
+                "long": ""
+            },
+            "topics": [
+                "system-software"
+            ]
         }
     }
 }

--- a/pages/index.md
+++ b/pages/index.md
@@ -9,9 +9,9 @@ permalink: /
 <p class="title-para">Welcome to the LLNL software portal—a hub for our open source projects. <br />Our <a href="/explore/#/AllSoftware">full catalog</a> is updated regularly as repositories are added or modified.</p>
 
 <section class="flex-container" id="categories">
-    <div ng-repeat="category in catData" class="flex-category dynamic" ng-click="categoryHref(category.title)">
+    <div ng-repeat="category in catData" class="flex-category dynamic">
         <img ng-src="{{ category.icon.path }}" style="width: 150px; height: 150px" alt="{{ category.icon.alt }}" />
-        <h4>{{ category.title }}</h4>
+        <h4><a ng-href="../explore#{{ category.hash}}">{{ category.title}}</a></h4>
         <p class="text-center">{{ category.description.short }}</p>
 
         <div ng-repeat="repo in topicRepos[catData.indexOf(category)]">


### PR DESCRIPTION
Partially fixes https://github.com/LLNL/llnl.github.io/issues/551 by renaming the hash path from `category` to `explore` and adding a new hash title to the category metadata. Now you cannot click on the whole category "box," but you click on its name (which changes to aqua on rollover) to get to, for instance, `/explore/#/BuildTools`.