### PR TITLE
Reorg & rename viz graphs

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,6 +26,7 @@
           <div class="dropdown-content">
             <p><a class="navbar-normal" href="/visualize/dependencies/">Dependencies</a></p>
             <p><a class="navbar-normal" href="/visualize/popular-repos/">Popular Repositories</a></p>
+            <p><a class="navbar-normal" href="/visualize/contributors/">Contributors</a></p>
           </div>
         </li>
         <li id="about"

--- a/css/main.css
+++ b/css/main.css
@@ -194,8 +194,7 @@ light gray background #ddd */
 
 /* Links in text on non-category pages */
 
-.static-text a,
-a:visited {
+.static-text a {
     color: #005dab;
     text-decoration: none;
     font-weight: bold;

--- a/js/visualize/contributors/pack_hierarchy.js
+++ b/js/visualize/contributors/pack_hierarchy.js
@@ -10,7 +10,7 @@ function draw_pack_hierarchy(areaID) {
     });
 
     function drawGraph(data, areaID) {
-        const graphHeader = 'Organizations and Contributions';
+        const graphHeader = 'Organizations and Contributors';
 
         const margin = { top: stdMargin.top, right: stdMargin.right, bottom: stdMargin.bottom, left: stdMargin.left },
             width = stdTotalWidth * 2 - margin.left - margin.right,
@@ -219,7 +219,7 @@ function draw_pack_hierarchy(areaID) {
         }
 
         // Data for legend
-        const labels = ['External Contributors', 'Internal Contributors', 'Repositories', 'GitHub Organizations', 'LLNL'];
+        const labels = ['External Contributors', 'Internal Contributors', 'Repositories', 'GitHub Organizations', 'LLNL Catalog'];
     
         // Creates legend
         const legend = chart

--- a/js/visualize/dependencies/force_dependencyGraph.js
+++ b/js/visualize/dependencies/force_dependencyGraph.js
@@ -8,7 +8,7 @@ function draw_force_graph(areaID, adjacentAreaID) {
 
     // Draws graph
     function drawGraph(data, areaID, adjacentAreaID) {
-        const graphHeader = 'LLNL Dependencies';
+        const graphHeader = '';
 
         const margin = { top: stdMargin.top, right: stdMargin.right / 2, bottom: stdMargin.bottom / 2, left: stdMargin.left / 2 },
             width = stdTotalWidth * 2 + 80 - margin.left - margin.right,

--- a/js/visualize/largeRepos/line_repoCreationHistory.js
+++ b/js/visualize/largeRepos/line_repoCreationHistory.js
@@ -10,7 +10,7 @@ function draw_line_repoCreationHistory(areaID, repoNamesWOwner) {
 
     // Draw graph from data
     function drawGraph(data, data2, dataR, dataR2, areaID) {
-        var graphHeader = `Repo Creation History, Top ${cutOffSize} Repos by Stars`;
+        var graphHeader = `Creation History, Top ${cutOffSize} Repos by Stars`;
         var seriesData = [{ label: 'First Commit' }, { label: 'Added to GitHub' }];
         var showSingle = dataR2.length ? true : false;
 

--- a/js/visualize/largeRepos/list_popularRepos.js
+++ b/js/visualize/largeRepos/list_popularRepos.js
@@ -4,7 +4,7 @@ function draw_popularRepos(areaID, columns=2, orthogonalOrdering=false) {
     drawList(data, areaID);
 
     function drawList(data, areaID) {
-        const graphHeader = 'Repo Popularity by Stars';
+        const graphHeader = 'Popularity by Stars';
 
         const rowSpacing = 5,
             columnSpacing = 15,
@@ -52,7 +52,7 @@ function draw_popularRepos(areaID, columns=2, orthogonalOrdering=false) {
             .join('text')
                 .attr('font-size', fontSize)
                 .attr('y', (d, i) => (fontSize + rowSpacing) * i)
-                .html(d => `<tspan style="font-weight: bold">${d.position}. </tspan><a xlink:href=${window.location['origin']}/repo/#/${d.entry.owner}/${d.entry.name}>${d.entry.owner}/${d.entry.name}</a>`);
+                .html(d => `<tspan style="font-weight:bold">${d.position}. </tspan><a xlink:href=${window.location['origin']}/repo/#/${d.entry.owner}/${d.entry.name}>${d.entry.owner}/${d.entry.name}</a>`);
 
         chart
             .append('g')

--- a/js/visualize/line_repoCreationHistory.js
+++ b/js/visualize/line_repoCreationHistory.js
@@ -10,7 +10,7 @@ function draw_line_repoCreationHistory(areaID, repoNameWOwner) {
 
     // Draw graph from data
     function drawGraph(data, data2, dataR, dataR2, areaID) {
-        var graphHeader = 'Repo Creation History';
+        var graphHeader = 'Creation History';
         var seriesData = [{ label: 'First Commit' }, { label: 'Added to GitHub' }];
         var showSingle = dataR2.length ? true : false;
 

--- a/pages/visualize/contributors.md
+++ b/pages/visualize/contributors.md
@@ -1,0 +1,52 @@
+---
+title: Visualize
+layout: default
+permalink: /visualize/contributors
+---
+
+{% raw %}
+
+<link rel="stylesheet" type="text/css" href="/css/graphstyle.css" />
+
+<h2 class="page-header text-center">
+    LLNL GitHub Visualizations: Contributors
+</h2>
+
+<!-- Preset vis display areas -->
+<center>
+    <svg class="pieMembers"></svg><svg class="pieRepos"></svg>
+    <br /><svg class="hierarchyPack"></svg>
+</center>
+
+<!-- Load basic D3 and helper scripts -->
+<script src="https://ajax.googleapis.com/ajax/libs/d3js/5.16.0/d3.min.js" charset="UTF-8"></script>
+<script type="text/javascript" src="../../static/d3-tip/1.0/d3-tip.js"></script>
+<script type="text/javascript" src="../../static/d3-v4-cloud/1.2.2/build/d3.layout.cloud.js"></script>
+<script type="text/javascript" src="https://unpkg.com/d3-simple-slider@1.8.0/dist/d3-simple-slider.min.js"></script>
+<script type="text/javascript" src="../../js/visualize/helpers.js"></script>
+
+<!-- Load drawing JS -->
+<script type="text/javascript" src="../../js/visualize/pie_members.js"></script>
+<script type="text/javascript" src="../../js/visualize/pie_repos.js"></script>
+<script type="text/javascript" src="../../js/visualize/contributors/pack_hierarchy.js"></script>
+
+<script>
+    // GiHub Data Directory
+    var ghDataDir = '../github-data';
+    // Global chart standards
+    var stdTotalWidth = 500,
+        stdTotalHeight = 400;
+    var stdMargin = { top: 40, right: 40, bottom: 40, left: 40 },
+        stdWidth = stdTotalWidth - stdMargin.left - stdMargin.right,
+        stdHeight = stdTotalHeight - stdMargin.top - stdMargin.bottom,
+        stdMaxBuffer = 1.07;
+    var stdDotRadius = 4,
+        stdLgndDotRadius = 5,
+        stdLgndSpacing = 20;
+    // Call draw functions
+    draw_pie_members('pieMembers');
+    draw_pie_repos('pieRepos');
+    draw_pack_hierarchy('hierarchyPack');
+</script>
+
+{% endraw %}

--- a/pages/visualize/dependencies.md
+++ b/pages/visualize/dependencies.md
@@ -10,7 +10,7 @@ permalink: /visualize/dependencies/
 <link rel="stylesheet" type="text/css" href="../../css/main.css" />
 
 <h2 class="page-header text-center">
-    LLNL GitHub Visualizations
+    LLNL GitHub Visualizations: Dependencies
 </h2>
 
 <!-- Preset vis display areas -->

--- a/pages/visualize/index.md
+++ b/pages/visualize/index.md
@@ -9,14 +9,12 @@ permalink: /visualize/
 <link rel="stylesheet" type="text/css" href="/css/graphstyle.css" />
 
 <h2 class="page-header text-center">
-    LLNL GitHub Visualizations
+    LLNL GitHub Visualizations: Repositories
 </h2>
 
 <!-- Preset vis display areas -->
 <center>
     <svg class="repoCreationHistory"></svg>
-    <br /><svg class="hierarchyPack"></svg>
-    <br /><svg class="pieMembers"></svg><svg class="pieRepos"></svg>
     <br /><svg class="repoActivityChart"></svg>
     <br /><svg class="repoStarHistoryChart"></svg>
     <br /><svg class="repoPulls"></svg><svg class="repoIssues"></svg>
@@ -33,15 +31,12 @@ permalink: /visualize/
 
 <!-- Load drawing JS -->
 <script type="text/javascript" src="../js/visualize/line_repoCreationHistory.js"></script>
-<script type="text/javascript" src="../js/visualize/pie_members.js"></script>
-<script type="text/javascript" src="../js/visualize/pie_repos.js"></script>
 <script type="text/javascript" src="../js/visualize/line_repoActivityExplore.js"></script>
 <script type="text/javascript" src="../js/visualize/scatter_repoPulls.js"></script>
 <script type="text/javascript" src="../js/visualize/scatter_repoIssues.js"></script>
 <script type="text/javascript" src="../js/visualize/pie_languageExplore.js"></script>
 <script type="text/javascript" src="../js/visualize/cloud_topics.js"></script>
 <script type="text/javascript" src="../js/visualize/sunburst_licenses.js"></script>
-<script type="text/javascript" src="../js/visualize/pack_hierarchy.js"></script>
 <script type="text/javascript" src="../js/visualize/line_repoStarHistoryExplore.js"></script>
 
 <script>
@@ -59,15 +54,12 @@ permalink: /visualize/
         stdLgndSpacing = 20;
     // Call draw functions
     draw_line_repoCreationHistory('repoCreationHistory');
-    draw_pie_members('pieMembers');
-    draw_pie_repos('pieRepos');
     draw_line_repoActivity('repoActivityChart');
     draw_scatter_repoPulls('repoPulls');
     draw_scatter_repoIssues('repoIssues');
     draw_pie_language('languagePie');
     draw_cloud_topics('topicCloud');
     draw_sunburst_licenses('licenseSunburst');
-    draw_pack_hierarchy('hierarchyPack');
     draw_line_repoStarHistory('repoStarHistoryChart');
 </script>
 

--- a/pages/visualize/popular-repos.md
+++ b/pages/visualize/popular-repos.md
@@ -9,7 +9,7 @@ permalink: /visualize/popular-repos/
 <link rel="stylesheet" type="text/css" href="../../css/graphstyle.css" />
 
 <h2 class="page-header text-center">
-    LLNL GitHub Visualizations
+    LLNL GitHub Visualizations: Popular Repos
 </h2>
 
 <!-- Preset vis display areas -->


### PR DESCRIPTION
- created a new Contributors page subordinate to main Visualize page
- moved two pie charts and the pack hierarchy chart to the new page
- gave each Viz page/sub-page a subtitle
- tightened up the name of the graphs on these pages as a result of page titles
- one minor CSS change that I felt was misleading