### PR TITLE
Added collaborator information query to dependency info

### DIFF
--- a/_visualize/queries/dependency-Info.gql
+++ b/_visualize/queries/dependency-Info.gql
@@ -14,6 +14,13 @@ query ($ownName: String!, $repoName: String!) {
         isVerified
       }
     }
+    collaborators {
+      nodes {
+        login
+        name
+        company
+      }
+    }
   }
 }
 # {"ownName": "LLNL", "repoName": "llnl.github.io"}


### PR DESCRIPTION
The intent here is to gather information about who contributes to our open source projects (and their dependencies).

@LRWeber -- I checked this in teh graphql explorer, but I've done very little overall with graphql, so would appreciate a second set of :eyes: