### PR TITLE
RADIUSS cleanup, part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Author: Ian Lee <lee1001@llnl.gov>
 
-Welcome to the Lawrence Livermore National Laboratory software portal! The purpose of this software portal is to serve as a hub for open source software that is produced by Lawrence Livermore National Laboratory.
+Welcome to the Lawrence Livermore National Laboratory software portal! The purpose of this software portal is to serve as a hub for open source software produced by LLNL.
 
 LLNL produces software on a daily basis. Some of this software is used only internally, other components are licensed for use by external partners and collaborators, still other software is released, or even actively developed, in the open on software hosting platforms such as GitHub.com, Bitbucket.org, Sourceforge.net, and others.
 
@@ -31,6 +31,8 @@ bundle exec jekyll serve
 ```
 
 Finally, open <http://localhost:4000> in a web browser.
+
+*Note:* The [RADIUSS website](https://software.llnl.gov/radiuss/) and [product catalog](https://software.llnl.gov/radiuss/projects/) "live" on this site but are managed by a [separate repo](https://github.com/LLNL/radiuss).
 
 ### Checking Spelling
 
@@ -61,10 +63,10 @@ Start with the [FAQ](https://software.llnl.gov/about/faq/). Please see the follo
 
 - [Project logos](https://github.com/LLNL/llnl.github.io/blob/main/assets/images/logos/README.md)
 - ["Explore" categories](https://github.com/LLNL/llnl.github.io/blob/main/pages/explore/README.md)
-- [RADIUSS tags](https://github.com/LLNL/llnl.github.io/blob/main/radiuss/README.md)
 - [News posts](https://github.com/LLNL/llnl.github.io/blob/main/news/README.md)
 - Data [visualizations](https://github.com/LLNL/llnl.github.io/blob/main/_visualize/README.md) and [scripts](https://github.com/LLNL/llnl.github.io/blob/main/_visualize/scripts/README.md)
 - [Data fetching](https://github.com/LLNL/llnl.github.io/blob/main/visualize/README.md)
+- [RADIUSS site](https://github.com/LLNL/radiuss/blob/main/README.md)
 
 ## Contact
 

--- a/assets/images/logos/README.md
+++ b/assets/images/logos/README.md
@@ -1,10 +1,10 @@
 # Project Logos
 
-The home page displays a logo next to each repo when they appear under the topic categories. This feature does not apply to the [Explore](https://software.llnl.gov/explore/#/AllSoftware) view.
+The home page displays a logo next to each repo when they appear under the topic categories. This feature applies only to the home page, not to the [Explore](https://software.llnl.gov/explore/#/AllSoftware) view.
 
 If a repo has its own logo, that should display. If not, then its organization's avatar should display. Every repo should have one logo or avatar; no repo should be "empty." Organization avatars are pulled from GitHub.
 
 Repo logo files should follow a naming convention and be added to the directory. All files must be in .png format.
 
-- Repository logo: `<repo_name>.png`
+- Repository logo: `<repo_name>.png` (`org.png` is acceptable for repos in non-LLNL orgs, as they are unique inside their directory folders)
 - Directory: `/assets/images/logos/<org name>`

--- a/pages/about/faq.md
+++ b/pages/about/faq.md
@@ -135,7 +135,7 @@ Now that your project is on GitHub, make sure users and contributors can find it
 
     * See helpful hints on [GitHub's topic help page](https://help.github.com/articles/about-topics/). Add tags relevant to your project's programming language, platforms, and more (e.g., Python, HPC, Linux).
 
-    * If your repo is part of the [RADIUSS project](/explore/#/RADIUSS), be sure to add the `radiuss` topic.
+    * If your repo is part of the [RADIUSS project](https://software.llnl.gov/radiuss/projects/), be sure to add it to that repo's [`contributor-ci.yaml` file](https://github.com/LLNL/radiuss/blob/main/contributor-ci.yaml).
 
 2. Let [Twitter](https://twitter.com/LLNL_OpenSource) followers know your project is available on GitHub. Feel free to tag this handle on your own tweet, or submit a request to [open-source@llnl.gov](mailto:open-source@llnl.gov) so we can tweet on your behalf.
 
@@ -151,11 +151,13 @@ Before contributing, please contact [open-source@llnl.gov](mailto:open-source@ll
 
 ### What should I do if my repo is no longer actively developed/maintained?
 
-1. Remove your repo’s topic tags (e.g., `math-physics`), which connect it to this website’s browsable categories. Also remove the `radiuss` tag, if applicable.
+1. Remove the specific topic tags (e.g., `math-physics`) that connect it to this website’s browsable categories.
 
-2. Submit a pull request [updating the `input_lists.json` file](https://github.com/LLNL/llnl.github.io/blob/main/_visualize/input_lists.json) to remove your repo’s name.
+2. Remove the repo from the RADIUSS [`contributor-ci.yaml` file](https://github.com/LLNL/radiuss/blob/main/contributor-ci.yaml), if applicable.
 
-3. Change your repo's status via Settings > Manage Access > Who has access > Manage > Danger Zone > Archive this repository (`settings#danger-zone`). Contact [open-source@llnl.gov](mailto:open-source@llnl.gov) if for some reason GitHub won't let you complete this step.
+3. Submit a pull request [updating the `input_lists.json` file](https://github.com/LLNL/llnl.github.io/blob/main/_visualize/input_lists.json) to remove your repo’s name.
+
+4. Change your repo's status via Settings > Manage Access > Who has access > Manage > Danger Zone > Archive this repository (`settings#danger-zone`). Contact [open-source@llnl.gov](mailto:open-source@llnl.gov) if for some reason GitHub won't let you complete this step.
 
 ### My repo has grown. How do I move it out of the LLNL organization?
 
@@ -167,7 +169,9 @@ Once the repository has moved to the new organization:
 
 1. Submit a pull request [updating the `input_lists.json` file](https://github.com/LLNL/llnl.github.io/blob/main/_visualize/input_lists.json) to add the new organization/repo’s name. This allows for the software catalog to continue including the project even after it moves.
 
-2. Retain topic tags (e.g., `math-physics`) to connect it to this website’s browsable categories, including the `radiuss` tag, if applicable.
+2. Retain topic tags (e.g., `math-physics`) to connect it to this website’s browsable categories.
+
+3. Update the org in the RADIUSS [`contributor-ci.yaml` file](https://github.com/LLNL/radiuss/blob/main/contributor-ci.yaml), if applicable.
 
 ### How do I contribute to an LLNL repo?
 

--- a/pages/explore/README.md
+++ b/pages/explore/README.md
@@ -23,7 +23,7 @@ For each category, this file contains its title, [icon][icon dir] filepath, and 
 
 In general, topic tags raise a repo's visibility on GitHub and help users find related projects. The following tags, which are are not associated with the home page categories above, are recommended for LLNL repos: `amr` (adaptive mesh refinement), `arbitrary-lagrangian-eulerian` (ALE), `artificial-intelligence`, `benchmark`, `checkpoint`, `chemistry`, `cmake`, `compiler`, `cpp` (C++), `data-analysis`, `deep-learning`, `energy`, `exascale-computing`, `finite-elements`, `fortran`, `gpu`, `graph`, `high-dimensional-data`, `hpc`, `java`, `javascript`, `library`, `machine-learning`, `materials`, `matlab`, `molecular-dynamics`, `monte-carlo`, `mpi`, `natural-language-processing`, `neural-network`, `openmp`, `parallel-computing`, `python`, `shell`, `simulation`, `solver`, `templates`, `testing`, `uncertainty-quantification`.
 
-Repos that appear in the [RADIUSS catalog](/explore/#/RADIUSS) must also be tagged with `radiuss`.
+Repos that appear on the [RADIUSS site](https://software.llnl.gov/radiuss/projects/) are listed in that repo's [`contributor-ci.yaml` file](https://github.com/LLNL/radiuss/blob/main/contributor-ci.yaml).
 
 To add a new category to the catalog:
 


### PR DESCRIPTION
Fulfills some tasks on https://github.com/LLNL/llnl.github.io/issues/567 by updating three READMEs and the FAQ to point to the new RADIUSS pages and custom `contributor-ci.yaml` file. Also made a few minor test edits for clarity while in those files.