### PR TITLE
Fix missing repo logos/avatars on home page

### DIFF
--- a/assets/images/logos/README.md
+++ b/assets/images/logos/README.md
@@ -4,7 +4,9 @@ The home page displays a logo next to each repo when they appear under the topic
 
 If a repo has its own logo, that should display. If not, then its organization's avatar should display. Every repo should have one logo or avatar; no repo should be "empty." Organization avatars are pulled from GitHub.
 
-Repo logo files should follow a naming convention and be added to the directory. All files must be in .png format.
+Repo logo files should follow a naming convention and be added to the [logos directory](https://github.com/LLNL/llnl.github.io/tree/main/assets/images/logos). All files must be in .png format.
 
 - Repository logo: `<repo_name>.png` (`org.png` is acceptable for repos in non-LLNL orgs, as they are unique inside their directory folders)
 - Directory: `/assets/images/logos/<org name>`
+
+An LLNL repo with its own logo also needs the image file name added to [`repo_logos.json`](https://github.com/LLNL/llnl.github.io/blob/main/assets/images/logos/repo_logos.json).

--- a/assets/images/logos/repo_logos.json
+++ b/assets/images/logos/repo_logos.json
@@ -6,10 +6,14 @@
         "llnl/caliper.png",
         "llnl/conduit.png",
         "llnl/cram.png",
+        "llnl/kosh.png",
         "llnl/macpatch.png",
+        "llnl/psuade.png",
         "llnl/raja.png",
+        "llnl/serac.png",
         "llnl/sundials.png",
         "llnl/umpire.png",
+        "llnl/unifyfs.png",
         "rose-compiler/rose.png"
     ]
 }


### PR DESCRIPTION
Closes https://github.com/LLNL/llnl.github.io/issues/564 by adding missing logo (avatar) file names to a `.json` file and updating the associated README instructions.