### PR TITLE
Comment out Twitter feed on news

### DIFF
--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
             <div class="container" style="margin-top: 30px;">
-                <div class="twitterFeed">
+<!--                <div class="twitterFeed">
                     <div class="tweet-border">
                     <h4 class="twitter-title">Latest from Twitter</h4>
                     <a class="twitter-timeline" data-chrome="nofooter noheader noborders" href="https://twitter.com/{{site.twitter.username}}" data-tweet-limit="2" title="twitter feed"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
@@ -11,13 +11,13 @@ layout: default
                         <a href="https://twitter.com/{{site.twitter.username}}" class="twitter-follow-button" data-show-count="false">Follow @LLNL_OpenSource</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
                     </div>
                     </div>
-                </div>
+                </div> -->
 
             {{ content }}
             
-            <div class="twitterFeed-mobile" >
+<!--            <div class="twitterFeed-mobile" >
                     <h4 class="twitter-title">Latest from Twitter</h4>
                     <a class="twitter-timeline" data-chrome="nofooter noheader" href="https://twitter.com/{{site.twitter.username}}" data-tweet-limit="2" title="twitter feed"></a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
                     <a href="https://twitter.com/{{site.twitter.username}}" class="twitter-follow-button" data-show-count="false">Follow @{{site.twitter.username}}</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-                </div>
+                </div> -->
             </div>


### PR DESCRIPTION
Twitter's API is broken and no ETA to fix it, so I commented out the empty feed display. Affects News and News Archive (the `news.html` layout). I'll reinstate it when/if it's working again.

![image](https://github.com/LLNL/llnl.github.io/assets/31740953/ff3fe823-9f0d-4669-9cef-c32e886a837f)
