### PR TITLE
Add Caliper tutorial to json file

### DIFF
--- a/_visualize/input_lists.json
+++ b/_visualize/input_lists.json
@@ -34,6 +34,7 @@
         "ceed/remhos",
         "chu11/freeipmi-mirror",
         "cmecmetrics/cmec-driver",
+        "daboehme/caliper-tutorial",
         "dun/conman",
         "dun/munge",
         "ecp-veloc/axl",


### PR DESCRIPTION
While Caliper lives inside the LLNL org, the tutorial does not. So I've added it to `input_lists.json`.