### PR TITLE
Stop update script writing to console

### DIFF
--- a/_visualize/scripts/MASTER.sh
+++ b/_visualize/scripts/MASTER.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Run this script to refresh all data for today
+# Run this script to refresh all data
 
-exec &> >(tee ../LAST_MASTER_UPDATE.log)
+exec &> ../LAST_MASTER_UPDATE.log
 
 export GITHUB_DATA=../../visualize/github-data
 DATELOG=../LAST_MASTER_UPDATE.txt


### PR DESCRIPTION
Writes to temporary log file only.
Intended to decrease the necessary runtime for the update script.