### PR TITLE
Add new cache request scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 _site
 Gemfile.lock
 *.pyc
-_visualize/LAST_MASTER_UPDATE.log
+_visualize/*.log
+_visualize/LAST_CACHE_REQUEST.txt
 .DS_Store
 .vscode/
 .bundle

--- a/_visualize/scripts/CACHE.sh
+++ b/_visualize/scripts/CACHE.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Run this script to trigger GitHub's data caching
+# https://docs.github.com/en/rest/metrics/statistics?apiVersion=2022-11-28#best-practices-for-caching
+
+exec &> ../LAST_CACHE_REQUEST.log
+
+export GITHUB_DATA=../../visualize/github-data
+DATELOG=../LAST_CACHE_REQUEST.txt
+
+# On exit
+function finish {
+    # Log end time
+    echo -e "END\t$(date -u)" >> $DATELOG
+}
+trap finish EXIT
+
+# Stop and Log for failed scripts
+function errorCheck() {
+    if [ $ret -ne 0 ]; then
+        echo "FAILED - $1"
+        echo -e "FAILED\t$1" >> $DATELOG
+        exit 1
+    fi
+}
+
+# Basic script run procedure
+function runScript() {
+    echo "Run - $1"
+    python -u $1
+    ret=$?
+    errorCheck "$1"
+}
+
+
+# Check Python requirements
+runScript python_check.py
+
+
+echo "RUNNING CACHE REQUEST SCRIPT"
+
+# Log start time
+echo -e "$(date -u '+%F-%H')" > $DATELOG
+echo -e "START\t$(date -u)" >> $DATELOG
+
+
+# --- CHACHEABLE QUERIES ---
+runScript cache_repos_activitycommits.py
+runScript cache_repos_activitylines.py
+
+
+echo "CACHE REQUEST COMPLETE"

--- a/_visualize/scripts/cache_repos_activitycommits.py
+++ b/_visualize/scripts/cache_repos_activitycommits.py
@@ -1,0 +1,43 @@
+from scraper.github import queryManager as qm
+from os import environ as env
+import re
+
+ghDataDir = env.get("GITHUB_DATA", "../github-data")
+query_in = "/repos/OWNNAME/REPONAME/stats/commit_activity"
+
+# Read repo info data file (to use as repo list)
+inputLists = qm.DataManager("%s/intReposInfo.json" % ghDataDir, True)
+# Populate repo list
+repolist = []
+print("Getting internal repos ...")
+repolist = sorted(inputLists.data["data"].keys())
+print("Repo list complete. Found %d repos." % (len(repolist)))
+
+# Initialize data collector
+dataCollector = qm.DataManager()
+dataCollector.data = {"data": {}}
+
+# Initialize query manager
+queryMan = qm.GitHubQueryManager(maxRetry=1, retryDelay=1)
+
+# Iterate through internal repos
+print("Gathering data across multiple queries...")
+for repo in repolist:
+    print("\n'%s'" % (repo))
+
+    r = repo.split("/")
+
+    gitquery = re.sub("OWNNAME", r[0], query_in)
+    gitquery = re.sub("REPONAME", r[1], gitquery)
+
+    try:
+        outObj = queryMan.queryGitHub(gitquery, rest=True)
+    except Exception as error:
+        print("Warning: Could not complete '%s'" % (repo))
+        print(error)
+        continue
+
+    print("'%s' Done!" % (repo))
+
+print("\nCache requests complete!")
+print("\nDone!\n")

--- a/_visualize/scripts/cache_repos_activitylines.py
+++ b/_visualize/scripts/cache_repos_activitylines.py
@@ -1,0 +1,43 @@
+from scraper.github import queryManager as qm
+from os import environ as env
+import re
+
+ghDataDir = env.get("GITHUB_DATA", "../github-data")
+query_in = "/repos/OWNNAME/REPONAME/stats/code_frequency"
+
+# Read repo info data file (to use as repo list)
+inputLists = qm.DataManager("%s/intReposInfo.json" % ghDataDir, True)
+# Populate repo list
+repolist = []
+print("Getting internal repos ...")
+repolist = sorted(inputLists.data["data"].keys())
+print("Repo list complete. Found %d repos." % (len(repolist)))
+
+# Initialize data collector
+dataCollector = qm.DataManager()
+dataCollector.data = {"data": {}}
+
+# Initialize query manager
+queryMan = qm.GitHubQueryManager(maxRetry=1, retryDelay=1)
+
+# Iterate through internal repos
+print("Gathering data across multiple queries...")
+for repo in repolist:
+    print("\n'%s'" % (repo))
+
+    r = repo.split("/")
+
+    gitquery = re.sub("OWNNAME", r[0], query_in)
+    gitquery = re.sub("REPONAME", r[1], gitquery)
+
+    try:
+        outObj = queryMan.queryGitHub(gitquery, rest=True)
+    except Exception as error:
+        print("Warning: Could not complete '%s'" % (repo))
+        print(error)
+        continue
+
+    print("'%s' Done!" % (repo))
+
+print("\nCache requests complete!")
+print("\nDone!\n")

--- a/_visualize/scripts/get_repos_creationhistory.py
+++ b/_visualize/scripts/get_repos_creationhistory.py
@@ -25,7 +25,7 @@ except FileNotFoundError:
     dataCollector.data = {"data": {}}
 
 # Initialize query manager
-queryMan = qm.GitHubQueryManager(maxRetry=10, retryDelay=1)
+queryMan = qm.GitHubQueryManager(maxRetry=20, retryDelay=2)
 
 # Iterate through internal repos
 print("Gathering data across multiple paginated queries...")


### PR DESCRIPTION
Running `CACHE.sh` a few hours prior to `MASTER.sh` should prompt GitHub to cache data for those requests ahead of time. This will optimize things for our main update workflow and minimize failures caused by the server-side process taking too long.