### PR TITLE
Update Check Spelling actions to latest versions.

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,8 +6,8 @@ jobs:
   spelling-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check Spelling
-        uses: crate-ci/typos@592b36d23c62cb378f6097a292bc902ee73f93ef # version 1.0.4
+        uses: crate-ci/typos@v1.16.12
         with:
           files: ./_posts ./pages ./README.md

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,12 @@
 [default.extend-identifiers]
-Varity = "Varity"
-varity = "varity"
+Cleary = "Cleary"
+compsite = "compsite"
 epsiode = "epsiode"
+NED = "NED"
+SUite = "SUite"
 Universite = "Universite"
+varity = "varity"
+Varity = "Varity"
+
+[default.extend-words]
+NED = "NED"


### PR DESCRIPTION
Includes new spelling exceptions as needed.

This will resolve the following warning on the completed Actions:
> **spelling-check**
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/