### PR TITLE
Stat printouts for auto update workflows

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -42,6 +42,13 @@ jobs:
         run: ./$ACTION_REPO/.github/scripts/cache.sh
         env:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+      - name: Show health stats
+        if: ${{ always() }}
+        run: |
+          cat $DATA_REPO/_visualize/LAST_CACHE_REQUEST.txt || true
+          echo "Warning Count: $(grep -c 'Warning' $DATA_REPO/_visualize/LAST_CACHE_REQUEST.log)"
+          echo "From Timeouts: $(grep -c 'but failed' $DATA_REPO/_visualize/LAST_CACHE_REQUEST.log)"
+          echo "Limit Reached: $(grep -c 'GITHUB NEEDS A BREAK' $DATA_REPO/_visualize/LAST_CACHE_REQUEST.log)"
       - name: Save log files
         if: ${{ always() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -42,6 +42,13 @@ jobs:
         run: ./$ACTION_REPO/.github/scripts/update.sh
         env:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+      - name: Show health stats
+        if: ${{ always() }}
+        run: |
+          cat $DATA_REPO/_visualize/LAST_MASTER_UPDATE.txt || true
+          echo "Warning Count: $(grep -c 'Warning' $DATA_REPO/_visualize/LAST_MASTER_UPDATE.log)"
+          echo "From Timeouts: $(grep -c 'but failed' $DATA_REPO/_visualize/LAST_MASTER_UPDATE.log)"
+          echo "Limit Reached: $(grep -c 'GITHUB NEEDS A BREAK' $DATA_REPO/_visualize/LAST_MASTER_UPDATE.log)"
       - name: Save log files
         if: ${{ always() }}
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Provides quick insight into the "health" of the update scripts without the need to review the full logs.
Most notably, it includes counts for the number of warnings that occurred, and how many of those warnings were due to timeouts (as opposed to expected warnings for other issues, e.g. empty repos).