### PR TITLE
Add AI&ML category to catalog browse

### DIFF
--- a/about/contributing.md
+++ b/about/contributing.md
@@ -70,14 +70,15 @@ If a word needs to be ignored, see [instructions](https://github.com/crate-ci/ty
   {% include components/accordion.html title='How do I build this site locally?' content=accordionContent %}
 
 {% capture accordionContent %}
-A [JSON file](https://github.com/LLNL/llnl.github.io/blob/main/visualize/github-data/category_info.json) contains the info for the software catalog categories displayed on the home page: title, Font Awesome icon, description. If any changes need to be made to these categories, just edit the data in the JSON and the home page will reflect your changes automatically. (These catalog categories/topics are distinct from the tags on [News posts](../../news).)
+A [JSON file](https://github.com/LLNL/llnl.github.io/blob/main/visualize/github-data/category_info.json) contains the info for the software catalog categories displayed on the home page: title, Font Awesome icon, description. If any changes need to be made to these categories, just edit the data in the JSON and the home page will reflect your changes automatically. (These catalog categories/topics are distinct from the tags on [News posts](../../news).) The list below contains each category's description to ensure consistency in phrasing and length. Note that in some cases the category is plural, but the corresponding tag is singular.
 
-The list below also contains each category's description to ensure consistency in phrasing and length. Note that in some cases the category is plural, but the corresponding tag is singular.
+**Note:** The `All Software` category appears at the top of the list by virtue of a blank space before the first letter in the `title` field (see the JSON file linked above). All other categories appear in alphabetical order.
 
 | -------- | ----------- | ------ | ------- |
 | Category | Description | Tag(s) | FA icon |
 | -------- | ----------- | ------ | ------- |
 | **All Software** | Browse all LLNL open source projects | (no tags required) | (image: `logomark-software.svg`) |
+| **AI & Machine Learning** | Integrate artificial intelligence and machine learning into scientific applications | `artificial-intelligence`, `deep-learning`, `machine-learning`, `neural-network` | fa-brain-circuit |
 | **App Infrastructure** | Browse tools for basic functionality common in HPC codes | `app-infrastructure` | fa-gear-complex-code |
 | **Applications** | Browse scientific simulation codes and IT management tools | `application` | fa-laptop-code |
 | **Build Tools** | Automate and simplify complex dependencies and deployments | `build-tools` | fa-tools |

--- a/visualize/github-data/category_info.json
+++ b/visualize/github-data/category_info.json
@@ -1,7 +1,7 @@
 {
     "data": {
         "All Software": {
-            "title": "All Software",
+            "title": " All Software",
             "hash": "AllSoftware",
             "icon": {
                 "path": "/assets/images/logomark-software.svg",
@@ -12,6 +12,24 @@
                 "long": ""
             },
             "topics": ""
+        },
+        "AI & Machine Learning": {
+            "title": "AI & Machine Learning",
+            "hash": "AI&ML",
+            "icon": {
+                "fa": "fa-brain-circuit",
+                "alt": "AI & ML"
+            },
+            "description": {
+                "short": "Integrate artificial intelligence and machine learning into scientific applications",
+                "long": ""
+            },
+            "topics":[
+                "artificial-intelligence",
+                "deep-learning",
+                "machine-learning",
+                "neural-network"
+            ]
         },
         "App Infrastructure": {
             "title": "App Infrastructure",


### PR DESCRIPTION
Added the category title, description, and FA icon. Documented these details and relevant topics on the Contribute page. Added a blank space to the title of "All Software" category so it will always appear at the top of the list ("AI" would come before it alphabetically).