### PR TITLE
Move IPO link to a better position

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,12 +27,19 @@ breadcrumb: Home
 <div class="bg-light-blue">
     <div class="container">
         <div class="row">
-            <div class="col-12 col-md-8 mb-3 mt-3">
-                <p class="fw-bold mt-4 cta-title">Looking for RADIUSS projects? </p>
-                <p class="cta-text">Find HPC build tools, math and physics libraries, data management and visualization tools, workflow tools, and portable programming and memory management libraries.</p>
+            <div class="col-12 col-md-8 mb-2 mt-2">
+                <p class="cta-text"><strong>Looking for RADIUSS projects?</strong> Find HPC build tools, math and physics libraries, data management and visualization tools, workflow tools, and portable programming and memory management libraries.</p>
             </div>
-            <div class="col-12 col-md-4 text-center d-flex align-items-center justify-content-center justify-content-lg-end mb-4 mb-md-0">
-                {% include components/button.html content="Browse RADIUSS Projects" url="/radiuss/projects/" icon="fa-search" tag="a" %}
+            <div class="col-12 col-md-4 text-center d-flex align-items-center justify-content-center justify-content-lg-end mb-1 mb-md-0">
+                {% include components/button.html content="Browse RADIUSS projects" url="https://software.llnl.gov/radiuss/projects/" icon="fa-search" tag="a" %}
+            </div>
+        </div>
+                <div class="row">
+            <div class="col-12 col-md-8 mb-2 mt-2">
+                <p class="cta-text"><strong>Looking for proprietary software solutions?</strong> The Innovation and Partnerships Office works with businesses interested in distributing software or incorporating LLNL software into commercial products.</p>
+            </div>
+            <div class="col-12 col-md-4 text-center d-flex align-items-center justify-content-center justify-content-lg-end mb-1 mb-md-0">
+                {% include components/button.html content="Browse proprietary software" url="https://softwarelicensing.llnl.gov" icon="fa-search" tag="a" %}
             </div>
         </div>
     </div>

--- a/visualize/github-data/category_info.json
+++ b/visualize/github-data/category_info.json
@@ -8,7 +8,7 @@
                 "alt": "All Software"
             },
             "description": {
-                "short": "Browse all LLNL open source projects below or visit LLNL Software Licensing (softwarelicensing.llnl.gov) for proprietary repos",
+                "short": "Browse LLNL projects below",
                 "long": ""
             },
             "topics": ""


### PR DESCRIPTION
The IPO folks requested a link to their site in the description of the All Software browse. I did that yesterday as a quick fix, but as the text is in a JSON file, there's no way to link it. So I've moved it into the RADIUSS "banner" above the browse. I don't know how to center align the text with the buttons (they are top aligned); that requires Bootstrap skills beyond what I have time to learn right now. In any case, this is more usable than yesterday's solution b/c the IPO link is actually clickable.

![image](https://github.com/LLNL/llnl.github.io/assets/31740953/24ae0bc3-9262-4fa5-a425-0ca5e67bf9d7)
