### PR TITLE
Extends Matomo Analytics

### DIFF
--- a/_includes/matomo.html
+++ b/_includes/matomo.html
@@ -2,6 +2,7 @@
 <!-- Piwik -->
 <script type="text/javascript">
   var _paq = _paq || [];
+  _paq.push(['trackVisibleContentImpressions']);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {

--- a/about/contributing.md
+++ b/about/contributing.md
@@ -28,7 +28,7 @@ To contribute to this website, please create a fork of [llnl.github.io](https://
 * Be explicit when opening issues and reporting bugs. What behavior are you expecting? What is your justification or use case for the new feature/enhancement? How can the bug be recreated? What are any environment variables to consider (e.g., browser, OS)?
 
 <!-- START: Accordions Each h2 below will be a separate accordion. -->
-<div class="accordion default border-top-gradient-software-blue-green border-bottom-gradient-software-blue-green">
+<div class="border-top-gradient-software-blue-green border-bottom-gradient-software-blue-green">
 
 {% capture accordionContent %}
 Before you begin, make sure you have working installs of Git, Ruby, and [Bundler](https://bundler.io). After you fork the repo, make sure you are in the directory you just created by running `cd llnl.github.io` Then you can use `bundler` to install the Ruby dependencies (see the [Jekyll installation docs](https://jekyllrb.com/docs/installation/) for step-by-step guides to setting this up):

--- a/about/index.md
+++ b/about/index.md
@@ -34,7 +34,7 @@ LLNL is a Department of Energy ([DOE](https://www.energy.gov/national-laboratori
   </div>
   <div class="col-12 col-lg-6 mb-3">
     <div class="responsive-iframe-container">
-      <iframe class="responsive-iframe" width="50%" src="https://www.youtube.com/embed/nTxMn1NWHQU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      <iframe class="responsive-iframe" width="50%" src="https://www.youtube.com/embed/nTxMn1NWHQU?enablejsapi=1" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
   </div>
 </div>

--- a/assets/js/news/news.js
+++ b/assets/js/news/news.js
@@ -82,6 +82,9 @@ angular.module("app", ['tid-custom']).controller("PostController", function($sco
 
     $scope.setCategory = function(category) {
         $scope.activeCategory = category;
+        if (typeof _paq !== 'undefined') {
+            _paq.push(['trackEvent', 'News', 'Category Filter', category]);
+        }
     }
 
     $scope.clearYear = function() {
@@ -89,10 +92,15 @@ angular.module("app", ['tid-custom']).controller("PostController", function($sco
     }
 
     $scope.setYear = function(year) {
+        var actionName = year;
         if (year === $scope.activeYear) {
             $scope.clearYear();
+            actionName = 'All';
         } else {
             $scope.activeYear = year;
+        }
+        if (typeof _paq !== 'undefined') {
+            _paq.push(['trackEvent', 'News', 'Year Filter', actionName]);
         }
     }
 });

--- a/assets/js/news/release.js
+++ b/assets/js/news/release.js
@@ -26,11 +26,16 @@ angular.module("app", ['ngAnimate']).controller("ReleaseController", function($s
     }
   
     $scope.setYear = function(year) {
+        var actionName = year;
         if (year === $scope.activeYear) {
             $scope.clearYear();
+            actionName = 'All';
         } else {
             $scope.activeYear = year;
-        } 
+        }
+        if (typeof _paq !== 'undefined') {
+            _paq.push(['trackEvent', 'Release', 'Year Filter', actionName]);
+        }
     }
 
     $scope.sortByPublishedAt = function(a, b) {

--- a/assets/js/projects/index.js
+++ b/assets/js/projects/index.js
@@ -63,10 +63,12 @@ angular.module("app", []).controller("ProjectController", function($scope) {
 
   $scope.range = range;
   $scope.console = console;
+  $scope.trackProjectImpressions = trackProjectImpressions;
 
   $scope.setPage = function(pageNumber) {
       $scope.pageNumber = 1;
       $scope.pageNumber = pageNumber;
+      $scope.trackProjectImpressions();
   }
 
   $scope.setCategory = function(category) {
@@ -75,6 +77,7 @@ angular.module("app", []).controller("ProjectController", function($scope) {
       if (typeof _paq !== 'undefined') {
         _paq.push(['trackEvent', 'Project', 'Category Filter', category.title]);
         $scope.trackSearchQuery(category, $scope.query);
+        $scope.trackProjectImpressions();
       }
   }
 
@@ -141,6 +144,7 @@ angular.module("app", []).controller("ProjectController", function($scope) {
               var repositories = Object.values(repositoryInfo.data);
               $scope.repositories = Object.values(repositories);
               $scope.$apply();
+              $scope.trackProjectImpressions();
           });
       });
   });
@@ -170,4 +174,19 @@ function recordSearchQuery(category, query, results) {
         results
     ]);
   }, 50);
+}
+
+
+function trackProjectImpressions(timeout) {
+  if (typeof _paq === 'undefined') {
+    return;
+  }
+  timeout = timeout || 500;
+  // wait for Angular to re-render before tracking new projects for impressions
+  setTimeout(function() {
+    const element = document.querySelector('#repository-container');
+    if (element) {
+      _paq.push(['trackContentImpressionsWithinNode', element]);
+    }
+  }, timeout);
 }

--- a/assets/js/projects/index.js
+++ b/assets/js/projects/index.js
@@ -1,192 +1,192 @@
 angular.module("app", []).controller("ProjectController", function($scope) {
-  $scope.query = '';
-  $scope.sortBy = '-stargazers.totalCount';
-  $scope.sortByReverse = false;
-  $scope.showProprietaryRepositories = true;
-  $scope.pageNumber = 1;
-  $scope.perPage = 12;
+    $scope.query = '';
+    $scope.sortBy = '-stargazers.totalCount';
+    $scope.sortByReverse = false;
+    $scope.showProprietaryRepositories = true;
+    $scope.pageNumber = 1;
+    $scope.perPage = 12;
 
-  $scope.categories = [];
-  $scope.repositories = [];
-  $scope.activeCategory = null;
-  $scope.Math = Math;
+    $scope.categories = [];
+    $scope.repositories = [];
+    $scope.activeCategory = null;
+    $scope.Math = Math;
 
-  $scope.typingTimer;
-  $scope.typingInterval = 1000;
+    $scope.typingTimer;
+    $scope.typingInterval = 1000;
 
 
-  $scope.trackSearchQuery = function(category, query) {
-      clearTimeout($scope.typingTimer);
-      $scope.typingTimer = setTimeout(function() {
-        // fetch number of search results
-        var results = $scope.repositories.filter($scope.filterByCategory).filter($scope.filterByQuery).filter($scope.filterByPrivacy).length;
-        recordSearchQuery(category, query, results);
-      }, $scope.typingInterval);
-  }
+    $scope.trackSearchQuery = function(category, query) {
+        clearTimeout($scope.typingTimer);
+        $scope.typingTimer = setTimeout(function() {
+            // fetch number of search results
+            var results = $scope.repositories.filter($scope.filterByCategory).filter($scope.filterByQuery).filter($scope.filterByPrivacy).length;
+            recordSearchQuery(category, query, results);
+        }, $scope.typingInterval);
+    }
 
-  $scope.filterByCategory = function(value) {
-      var isInCategory = false;
-      if ($scope.activeCategory.topics) {
-          if (value.topics && value.topics.length) {
-              for (var i = 0; i < value.topics.length; i++) {
-                  var valueTopic = value.topics[i];
-                  if ($scope.activeCategory.topics.indexOf(valueTopic.topic.name) > -1) {
-                      isInCategory = true;
-                      break;
-                  }
-              }
-          }
-      } else {
-          isInCategory = true;
-      }
-      return isInCategory;
-  };
+    $scope.filterByCategory = function(value) {
+        var isInCategory = false;
+        if ($scope.activeCategory.topics) {
+            if (value.topics && value.topics.length) {
+                for (var i = 0; i < value.topics.length; i++) {
+                    var valueTopic = value.topics[i];
+                    if ($scope.activeCategory.topics.indexOf(valueTopic.topic.name) > -1) {
+                        isInCategory = true;
+                        break;
+                    }
+                }
+            }
+        } else {
+            isInCategory = true;
+        }
+        return isInCategory;
+    };
 
-  $scope.filterByPrivacy = function(value) {
-      if ($scope.showProprietaryRepositories) {
-          return true;
-      }
-      return !value.isProprietary;
-  };
+    $scope.filterByPrivacy = function(value) {
+        if ($scope.showProprietaryRepositories) {
+            return true;
+        }
+        return !value.isProprietary;
+    };
 
-  $scope.filterByQuery = function(value) {
-      var queryMatch = true;
-      if (!$scope.query || !$scope.query.trim()) {
-          return true;
-      }
-      var query = $scope.query.toLowerCase(),
-          name = value.name.toLowerCase(),
-          description = value.description ? value.description.toLowerCase() : '',
-          queryMatch = name.indexOf(query) > -1 || description.indexOf(query) > -1;
-      return queryMatch;
-  };
+    $scope.filterByQuery = function(value) {
+        var queryMatch = true;
+        if (!$scope.query || !$scope.query.trim()) {
+            return true;
+        }
+        var query = $scope.query.toLowerCase(),
+            name = value.name.toLowerCase(),
+            description = value.description ? value.description.toLowerCase() : '',
+            queryMatch = name.indexOf(query) > -1 || description.indexOf(query) > -1;
+        return queryMatch;
+    };
 
-  $scope.range = range;
-  $scope.console = console;
-  $scope.trackProjectImpressions = trackProjectImpressions;
+    $scope.range = range;
+    $scope.console = console;
+    $scope.trackProjectImpressions = trackProjectImpressions;
 
-  $scope.setPage = function(pageNumber) {
-      $scope.pageNumber = 1;
-      $scope.pageNumber = pageNumber;
-      $scope.trackProjectImpressions();
-  }
-
-  $scope.setCategory = function(category) {
-      $scope.pageNumber = 1;
-      $scope.activeCategory = category;
-      if (typeof _paq !== 'undefined') {
-        _paq.push(['trackEvent', 'Project', 'Category Filter', category.title]);
-        $scope.trackSearchQuery(category, $scope.query);
+    $scope.setPage = function(pageNumber) {
+        $scope.pageNumber = 1;
+        $scope.pageNumber = pageNumber;
         $scope.trackProjectImpressions();
-      }
-  }
+    }
 
-  $scope.onCategoryChange = function() {
-      if ($scope.activeCategory.url) {
-          window.location.href = $scope.activeCategory.url;
-      }
-  }
+    $scope.setCategory = function(category) {
+        $scope.pageNumber = 1;
+        $scope.activeCategory = category;
+        if (typeof _paq !== 'undefined') {
+            _paq.push(['trackEvent', 'Project', 'Category Filter', category.title]);
+            $scope.trackSearchQuery(category, $scope.query);
+            $scope.trackProjectImpressions();
+        }
+    }
 
-  $scope.$evalAsync(function() {
-      const dataSubdomain = '/visualize/github-data/',
-          categoryInfoURL = dataSubdomain + 'category_info.json',
-          repositoryTopicsURL = dataSubdomain + 'intRepos_Topics.json',
-          repositoryInfoURL = dataSubdomain + 'intReposInfo.json',
-          repositoryInfoProprietaryURL = dataSubdomain + 'intReposInfo_Private.json',
-          repositoryLogoURL = dataSubdomain + 'repo_logos.json',
-          categoryPromise = window.fetch(categoryInfoURL),
-          repositoryTopicsPromise = window.fetch(repositoryTopicsURL),
-          repositoryInfoPromise = window.fetch(repositoryInfoURL),
-          repositoryInfoProprietaryPromise = window.fetch(repositoryInfoProprietaryURL),
-          repositoryLogoPromise = window.fetch(repositoryLogoURL);
+    $scope.onCategoryChange = function() {
+        if ($scope.activeCategory.url) {
+            window.location.href = $scope.activeCategory.url;
+        }
+    }
 
-      Promise.all([categoryPromise, repositoryTopicsPromise, repositoryInfoPromise, repositoryInfoProprietaryPromise, repositoryLogoPromise]).then(function(responses) {
-          const promises = [];
-          for (var i = 0; i < responses.length; i++) {
-              var response = responses[i];
-              if (!response.ok) {
-                  throw Error(response.url + ' failed to resolve: ' + response.statusText);
-              }
-              promises.push(response.json());
-          }
-          Promise.all(promises).then(function(data) {
-              const categoryInfo = data[0],
-                  repositoryTopics = data[1],
-                  repositoryInfo = data[2],
-                  repositoryInfoProprietary = data[3],
-                  repositoryLogos = data[4];
-              $scope.categories = Object.values(categoryInfo.data);
-              $scope.activeCategory = categoryInfo.data['All Software'];
+    $scope.$evalAsync(function() {
+        const dataSubdomain = '/visualize/github-data/',
+            categoryInfoURL = dataSubdomain + 'category_info.json',
+            repositoryTopicsURL = dataSubdomain + 'intRepos_Topics.json',
+            repositoryInfoURL = dataSubdomain + 'intReposInfo.json',
+            repositoryInfoProprietaryURL = dataSubdomain + 'intReposInfo_Private.json',
+            repositoryLogoURL = dataSubdomain + 'repo_logos.json',
+            categoryPromise = window.fetch(categoryInfoURL),
+            repositoryTopicsPromise = window.fetch(repositoryTopicsURL),
+            repositoryInfoPromise = window.fetch(repositoryInfoURL),
+            repositoryInfoProprietaryPromise = window.fetch(repositoryInfoProprietaryURL),
+            repositoryLogoPromise = window.fetch(repositoryLogoURL);
 
-              for (var key in repositoryInfo.data) {
-                  repositoryInfo.data[key].displayName = repositoryInfo.data[key].nameWithOwner;
-                  repositoryInfo.data[key] = repositoryInfo.data[key];
-              }
+        Promise.all([categoryPromise, repositoryTopicsPromise, repositoryInfoPromise, repositoryInfoProprietaryPromise, repositoryLogoPromise]).then(function(responses) {
+            const promises = [];
+            for (var i = 0; i < responses.length; i++) {
+                var response = responses[i];
+                if (!response.ok) {
+                    throw Error(response.url + ' failed to resolve: ' + response.statusText);
+                }
+                promises.push(response.json());
+            }
+            Promise.all(promises).then(function(data) {
+                const categoryInfo = data[0],
+                    repositoryTopics = data[1],
+                    repositoryInfo = data[2],
+                    repositoryInfoProprietary = data[3],
+                    repositoryLogos = data[4];
+                $scope.categories = Object.values(categoryInfo.data);
+                $scope.activeCategory = categoryInfo.data['All Software'];
 
-              for (var key in repositoryInfoProprietary.data) {
-                  repositoryInfoProprietary.data[key].isProprietary = true;
-                  repositoryInfoProprietary.data[key].displayName = repositoryInfoProprietary.data[key].name;
-                  repositoryInfo.data[key] = repositoryInfoProprietary.data[key];
-              }
+                for (var key in repositoryInfo.data) {
+                    repositoryInfo.data[key].displayName = repositoryInfo.data[key].nameWithOwner;
+                    repositoryInfo.data[key] = repositoryInfo.data[key];
+                }
 
-              for (var key in repositoryTopics.data) {
-                  repositoryInfo.data[key].topics = repositoryTopics.data[key].repositoryTopics.nodes;
-              }
-              for (var key in repositoryInfo.data) {
-                  var newKey = key.toLowerCase();
-                  for (var i = 0; i < repositoryLogos.data.length; i++) {
-                      var logo = repositoryLogos.data[i];
-                      if (logo.includes(newKey)) {
-                          repositoryInfo.data[key].logo = logo;
-                      }
-                  }
-              }
-              var repositories = Object.values(repositoryInfo.data);
-              $scope.repositories = Object.values(repositories);
-              $scope.$apply();
-              $scope.trackProjectImpressions();
-          });
-      });
-  });
+                for (var key in repositoryInfoProprietary.data) {
+                    repositoryInfoProprietary.data[key].isProprietary = true;
+                    repositoryInfoProprietary.data[key].displayName = repositoryInfoProprietary.data[key].name;
+                    repositoryInfo.data[key] = repositoryInfoProprietary.data[key];
+                }
+
+                for (var key in repositoryTopics.data) {
+                    repositoryInfo.data[key].topics = repositoryTopics.data[key].repositoryTopics.nodes;
+                }
+                for (var key in repositoryInfo.data) {
+                    var newKey = key.toLowerCase();
+                    for (var i = 0; i < repositoryLogos.data.length; i++) {
+                        var logo = repositoryLogos.data[i];
+                        if (logo.includes(newKey)) {
+                            repositoryInfo.data[key].logo = logo;
+                        }
+                    }
+                }
+                var repositories = Object.values(repositoryInfo.data);
+                $scope.repositories = Object.values(repositories);
+                $scope.$apply();
+                $scope.trackProjectImpressions();
+            });
+        });
+    });
 });
 
 function range(min, max, step) {
-  step = step || 1;
-  var input = [];
-  for (var i = min; i <= max; i += step) {
-      input.push(i);
-  }
-  return input;
+    step = step || 1;
+    var input = [];
+    for (var i = min; i <= max; i += step) {
+        input.push(i);
+    }
+    return input;
 };
 
 function recordSearchQuery(category, query, results) {
-  if (typeof _paq === 'undefined') {
-    return;
-  }
-  setTimeout(function() {
-    var searchCategory = category ? category.title : '';
-    _paq.push(['trackSiteSearch',
-        // Search keyword searched for
-        query,
-        // Search category selected in your search engine. If you do not need this, set to false
-        searchCategory,
-        // Number of results on the Search results page. Zero indicates a 'No Result Search Keyword'. Set to false if you don't know
-        results
-    ]);
-  }, 50);
+    if (typeof _paq === 'undefined') {
+        return;
+    }
+    setTimeout(function() {
+        var searchCategory = category ? category.title : '';
+        _paq.push(['trackSiteSearch',
+            // Search keyword searched for
+            query,
+            // Search category selected in your search engine. If you do not need this, set to false
+            searchCategory,
+            // Number of results on the Search results page. Zero indicates a 'No Result Search Keyword'. Set to false if you don't know
+            results
+        ]);
+    }, 50);
 }
 
 
 function trackProjectImpressions(timeout) {
-  if (typeof _paq === 'undefined') {
-    return;
-  }
-  timeout = timeout || 500;
-  // wait for Angular to re-render before tracking new projects for impressions
-  setTimeout(function() {
-    const element = document.querySelector('#repository-container');
-    if (element) {
-      _paq.push(['trackContentImpressionsWithinNode', element]);
+    if (typeof _paq === 'undefined') {
+        return;
     }
-  }, timeout);
+    timeout = timeout || 500;
+    // wait for Angular to re-render before tracking new projects for impressions
+    setTimeout(function() {
+        const element = document.querySelector('#repository-container');
+        if (element) {
+            _paq.push(['trackContentImpressionsWithinNode', element]);
+        }
+    }, timeout);
 }

--- a/assets/js/projects/index.js
+++ b/assets/js/projects/index.js
@@ -43,8 +43,8 @@ angular.module("app", []).controller("ProjectController", function($scope) {
       }
       var query = $scope.query.toLowerCase(),
           name = value.name.toLowerCase(),
-          description = value.description ? value.description.toLowerCase() : '';
-      queryMatch = name.indexOf(query) > -1 || description.indexOf(query) > -1;
+          description = value.description ? value.description.toLowerCase() : '',
+          queryMatch = name.indexOf(query) > -1 || description.indexOf(query) > -1;
       return queryMatch;
   };
 

--- a/assets/js/projects/index.js
+++ b/assets/js/projects/index.js
@@ -11,6 +11,19 @@ angular.module("app", []).controller("ProjectController", function($scope) {
   $scope.activeCategory = null;
   $scope.Math = Math;
 
+  $scope.typingTimer;
+  $scope.typingInterval = 1000;
+
+
+  $scope.trackSearchQuery = function(category, query) {
+      clearTimeout($scope.typingTimer);
+      $scope.typingTimer = setTimeout(function() {
+        // fetch number of search results
+        var results = $scope.repositories.filter($scope.filterByCategory).filter($scope.filterByQuery).filter($scope.filterByPrivacy).length;
+        recordSearchQuery(category, query, results);
+      }, $scope.typingInterval);
+  }
+
   $scope.filterByCategory = function(value) {
       var isInCategory = false;
       if ($scope.activeCategory.topics) {
@@ -61,6 +74,7 @@ angular.module("app", []).controller("ProjectController", function($scope) {
       $scope.activeCategory = category;
       if (typeof _paq !== 'undefined') {
         _paq.push(['trackEvent', 'Project', 'Category Filter', category.title]);
+        $scope.trackSearchQuery(category, $scope.query);
       }
   }
 
@@ -140,3 +154,20 @@ function range(min, max, step) {
   }
   return input;
 };
+
+function recordSearchQuery(category, query, results) {
+  if (typeof _paq === 'undefined') {
+    return;
+  }
+  setTimeout(function() {
+    var searchCategory = category ? category.title : '';
+    _paq.push(['trackSiteSearch',
+        // Search keyword searched for
+        query,
+        // Search category selected in your search engine. If you do not need this, set to false
+        searchCategory,
+        // Number of results on the Search results page. Zero indicates a 'No Result Search Keyword'. Set to false if you don't know
+        results
+    ]);
+  }, 50);
+}

--- a/assets/js/projects/index.js
+++ b/assets/js/projects/index.js
@@ -59,6 +59,9 @@ angular.module("app", []).controller("ProjectController", function($scope) {
   $scope.setCategory = function(category) {
       $scope.pageNumber = 1;
       $scope.activeCategory = category;
+      if (typeof _paq !== 'undefined') {
+        _paq.push(['trackEvent', 'Project', 'Category Filter', category.title]);
+      }
   }
 
   $scope.onCategoryChange = function() {

--- a/index.md
+++ b/index.md
@@ -95,12 +95,12 @@ breadcrumb: Home
                 </div>
                 <div class="row fs-14 fw-medium">
                     <div class="col-12 col-lg-6 d-flex align-items-center mb-4 mb-md-0">
-                        <input class="form-control fs-14 fw-semibold" type="text" name="query" placeholder="What are you looking for?" ng-model="query" ng-keyup="trackSearchQuery(activeCategory, query)" ng-blur="trackSearchQuery(activeCategory, query)" />
+                        <input class="form-control fs-14 fw-semibold" type="text" name="query" placeholder="What are you looking for?" ng-model="query" ng-keyup="trackSearchQuery(activeCategory, query)" ng-blur="trackSearchQuery(activeCategory, query)" ng-change="trackProjectImpressions()" />
                         <i class="fa fa-light fa-search text-software-blue ms--2"></i>
                     </div>
                     <div class="col-7 col-md-6 col-lg-3 d-flex align-items-center text-quantum-slate mt-md-2">
                         <div class="form-check form-switch">
-                            <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault" ng-model="showProprietaryRepositories" style="height: 1.5em; width: 3em;">
+                            <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefault" ng-model="showProprietaryRepositories" style="height: 1.5em; width: 3em;" ng-change="trackProjectImpressions()" >
                             <label class="form-check-label fw-medium fs-14 ms-2" for="flexSwitchCheckDefault">Show proprietary repos </label><i class="fa fa-light fa-lock ms-2"></i>
                         </div>
                     </div>
@@ -109,7 +109,7 @@ breadcrumb: Home
                             <label class="col-form-label fw-medium">Sort by</label>
                         </div>
                         <div class="col-8 px-0">
-                            <select class="form-control form-select fs-14 fw-semibold sort-by" id="sort" name="sort" ng-model="sortBy">
+                            <select class="form-control form-select fs-14 fw-semibold sort-by" id="sort" name="sort" ng-model="sortBy" ng-change="trackProjectImpressions()" >
                                 <option value="-stargazers.totalCount">Stars</option>
                                 <option value="owner.login">Organization</option>
                                 <option value="name">Repo Name</option>
@@ -120,7 +120,7 @@ breadcrumb: Home
                     </div>  
                 </div>
                 <div class="row mt-3 gx-27 gy-27" id="repository-container">
-                    <div class="col-12 col-md-6 col-xl-4 text-decoration-none text-black llnl-card-perspective transition-slide-up" ng-repeat="repository in filteredRepositories = (repositories | filter:filterByCategory | filter:filterByQuery | filter:filterByPrivacy) | orderBy: sortBy : sortByReverse | limitTo: perPage : perPage * (pageNumber - 1)">
+                    <div class="col-12 col-md-6 col-xl-4 text-decoration-none text-black llnl-card-perspective transition-slide-up" ng-repeat="repository in filteredRepositories = (repositories | filter:filterByCategory | filter:filterByQuery | filter:filterByPrivacy) | orderBy: sortBy : sortByReverse | limitTo: perPage : perPage * (pageNumber - 1)" data-track-content="" data-content-name="{{ repository.displayName }}" data-content-piece="{{ repository.logo ? '/assets/images/logos/' + repository.logo : '/assets/images/logomark.png' }}" data-content-target="{{ repository.url }}" >
                         <div class="llnl-card d-flex flex-column justify-content-between box-shadow-16 text-decoration-none text-black bg-white">
                             <div class="header text-center mt-4 position-relative px-4">
                                 <i ng-if="repository.isProprietary" class="fa fa-light fa-lock float-end translate-middle-x position-absolute top-5 right-5" style="top: 1em; right: 1em;"></i>

--- a/index.md
+++ b/index.md
@@ -95,7 +95,7 @@ breadcrumb: Home
                 </div>
                 <div class="row fs-14 fw-medium">
                     <div class="col-12 col-lg-6 d-flex align-items-center mb-4 mb-md-0">
-                        <input class="form-control fs-14 fw-semibold" type="text" name="query" placeholder="What are you looking for?" ng-model="query" />
+                        <input class="form-control fs-14 fw-semibold" type="text" name="query" placeholder="What are you looking for?" ng-model="query" ng-keyup="trackSearchQuery(activeCategory, query)" ng-blur="trackSearchQuery(activeCategory, query)" />
                         <i class="fa fa-light fa-search text-software-blue ms--2"></i>
                     </div>
                     <div class="col-7 col-md-6 col-lg-3 d-flex align-items-center text-quantum-slate mt-md-2">


### PR DESCRIPTION
Adds the following Matomo enhancements:

* **Releases** - Track filtering by year as [custom Events](https://matomo.org/guide/reports/event-tracking/)
* **News** - Track filtering by year and category as [custom Events](https://matomo.org/guide/reports/event-tracking/)
* **Projects/Repositories**
  * Track filtering by category as [custom Events](https://matomo.org/guide/reports/event-tracking/)
  * Track searches by category and query in Matomo [site search](https://matomo.org/guide/reports/site-search/), along with number of total results
  * Track [impressions/clicks](https://matomo.org/guide/reports/content-tracking/) to distinguish which projects/repositories have been seen by a user in their search results

Other enhancements:
* Removes an extraneous `accordion` class from the contributions page to prevent a duplicate Accordion action from being recorded in Matomo
* Corrects a variable definition