### PR TITLE
adds internal vs anonymous user tracking

### DIFF
--- a/_includes/matomo.html
+++ b/_includes/matomo.html
@@ -1,17 +1,69 @@
 {% if site.environment == 'production' and site.piwik_id %}
 <!-- Piwik -->
 <script type="text/javascript">
-  var _paq = _paq || [];
-  _paq.push(['trackVisibleContentImpressions']);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//analytics.llnl.gov/";
-    _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', {{ site.piwik_id }}]);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
-  })();
+    var _paq = _paq || [];
+    pingUserType('https://osc.llnl.gov/ping/', function(userType) {
+      _paq.push(['setCustomDimension', 1, userType, 'visit']);
+      _paq.push(['trackVisibleContentImpressions']);
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+
+      (function() {
+        var u="//analytics.llnl.gov/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', {{ site.piwik_id }}]);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    });
+
+    function pingUserType(url, callbackFn) {
+        /**
+         * Pings the specified URL, and stores last result in localStorage,
+         * if possible. If localStorage cache is marked as an internal user,
+         * will send to Matomo without ping re-verification.
+         **/
+        var pingKey = 'userType',
+            defaultUserType = 'Anonymous',
+            internalUserType = 'Internal',
+            userType = defaultUserType;
+
+        // check localStorage cache (previous pings) for userType, if possible
+        if ("localStorage" in window) {
+            userType = localStorage.getItem(pingKey) || defaultUserType;
+        }
+
+        // if identified as internal from localStorage cache, record as internal
+        if (userType === internalUserType) {
+            recordUserType(userType);
+            return;
+        }
+
+        // use ping URL to attempt to determine user type
+        var xhr = new XMLHttpRequest();
+        xhr.onreadystatechange = function() {
+            if (this.readyState == 4) {
+                var isSuccess = this.status >= 200 && this.status < 400;
+                if (isSuccess) {
+                    userType = internalUserType;
+                }
+                recordUserType(userType);
+            }
+        };
+
+        // consider a timeout to be an unsuccessful attempt
+        xhr.ontimeout = function() {
+            recordUserType(userType);
+        };
+        xhr.timeout = 500;
+        xhr.open('GET', url, true);
+        xhr.send();
+
+        function recordUserType(userType) {
+            localStorage.setItem(pingKey, userType);
+            callbackFn(userType);
+        }
+    }
 </script>
 <noscript><p><img src="//analytics.llnl.gov/piwik.php?idsite={{ site.piwik_id }}" style="border:0;" alt="" /></p></noscript>
 <!-- End Piwik Code -->


### PR DESCRIPTION
Updates site to use the same tracking logic as llnl.gov to distinguish between known internal users vs anonymous users by configuring a [Custom Dimension](https://matomo.org/guide/reporting-tools/custom-dimensions/).  This will allow Matomo to associate page views/events/etc being from an Internal/Anonymous user, and for Matomo users to be able segment users/events/etc by the corresponding User Type.

## Mechanism
The updated tracking script makes an HTTP call to an internal LLNL URL from the Matomo tracking snippet on the website prior to recording Matomo page views.  If the HTTP call succeeds in any capacity (not a 404 HTTP response code), the user can be assumed to be either on-site or connected to the VPN, and thus marked as a Lab-affiliated/internal visitor.  If not, the user can be assumed to not be affiliated with LLNL and be marked as `Anonymous`.

This method ensures Lab employees connected via VPN or on-site at the time they visit the website are recorded as `internal` users.  So, if I first visit the website from off-site and am not on the VPN, I would not be recorded as a Lab-affiliated visitor, despite being an employee visiting from a Lab-issue machine.  This is the only solution I am aware of which does not make any assumptions about data sent to Matomo such as ISP.

After a visitor has been identified as Lab-affiliated/`internal`, on subsequent visits they will be recorded as `internal` regardless of if they are connected to the VPN, as the tracking mechanism stores their `userType` between page views via `localStorage` in their browser.  If they are not Lab-affiliated, this logic will continue to ping the internal URL on each subsequent page view and record their user type based on the result of that ping.

### Matomo Configuration
Create the “User Type” Custom Dimension in Matomo as Visit Dimension 1 for this website (which I can do if/when this change has been deployed).  