### PR TITLE
Refresh About page and other scattered updates

### DIFF
--- a/about/contributing.md
+++ b/about/contributing.md
@@ -47,7 +47,7 @@ Finally, open <http://localhost:4000> in a web browser.
 
 *Note:* The [RADIUSS website](https://software.llnl.gov/radiuss/) and [product catalog](https://software.llnl.gov/radiuss/projects/) "live" on this URL but are managed by a [separate repo](https://github.com/LLNL/radiuss).
 
-### Tips
+## Tips
 
 The gems in your sourcefile get updated frequently. It is a good idea to occasionally run `bundle update` from within your project's root directory to make sure the software on your computer is up to date.
 
@@ -55,7 +55,7 @@ Sometimes there can be dependency conflicts if your local version of Ruby is dif
 
 For example, the default version of Ruby used to deploy GitHub Pages on github.com as of 2021-04-08 was Ruby 2.7.1. If you tried running Ruby version 3.0.0 locally on macOS, you'll need to do some extra steps to correctly install the dependencies for this repository. You'd need to run `bundle add webrick` as it is no longer a prepackaged dependency with Ruby in 3.0.0. You may also need to run `gem install eventmachine -- --with-openssl-dir=/usr/local/opt/openssl@1.1` as MacOS >10.14 doesn't use OpenSSL from the same path as is still assumed to be in by eventmachine.
 
-### Spellcheck
+## Spellcheck
 
 The [GitHub workflow](https://github.com/LLNL/llnl.github.io/blob/main/.github/workflows/main.yaml) currently includes an action for a Rust tool called [crate-ci/typos](https://github.com/marketplace/actions/typos-action) that will spellcheck all posts and pages. If your CI fails, spelling suggestions will be shown and you can manually update the mistakes, or [install typos](https://github.com/crate-ci/typos#install) and have all errors fixed automatically:
 
@@ -63,7 +63,7 @@ The [GitHub workflow](https://github.com/LLNL/llnl.github.io/blob/main/.github/w
 typos ./_posts ./README.md ./about/faq.md ./about/contributing.md --write-changes
 ```
 
-If a word needs to be ignored, see [instructions](https://github.com/crate-ci/typos#false-positives) for adding an entry to the [_typos.toml](https://github.com/LLNL/llnl.github.io/blob/main/_typos.toml) file.
+If a word needs to be ignored, see [instructions](https://github.com/crate-ci/typos#false-positives) for adding an entry to the [`_typos.toml`](https://github.com/LLNL/llnl.github.io/blob/main/_typos.toml) file.
 
 {% endcapture %}
   {% assign accordionContent = accordionContent | markdownify %}
@@ -112,11 +112,11 @@ Repos that appear on the [RADIUSS site](https://software.llnl.gov/radiuss/projec
 
 {% capture accordionContent %}
 
-### Project Tags
+## Project Tags
 
 See the FAQ [How do I include my repo in the LLNL organization and/or this website’s catalog?](https://software.llnl.gov/about/faq/#catalog) for information about tagging an individual repo. See the topic [How do I update or use the catalog categories?](https://software.llnl.gov/about/contribute/#categories) above for information about managing the categories.
 
-### Project Logos
+## Project Logos
 
 The home page displays a logo next to each repo when they appear under the topic categories. If a repo has its own logo, that should display. If not, then the LLNL logo displays by default. There are two steps to adding a logo to this website:
 
@@ -167,7 +167,7 @@ The informational pages on this site (e.g., this page, [About](/about), [FAQ](/a
 * News post titles in title case
 * Accordion titles in the form of a sentence-case question
 
-**To update the banner on the home page:** The existing RADIUSS message is in a container using the [`button.html` include file](https://github.com/LLNL/llnl.github.io/blob/main/_includes/components/button.html).
+**To update the banners on the home page:** The existing RADIUSS and IPO messages are in `<div>` containers using the [`button.html` include file](https://github.com/LLNL/llnl.github.io/blob/main/_includes/components/button.html).
 
 **To modify the site menu:** Update the menu in the [`header.html`](https://github.com/LLNL/llnl.github.io/blob/main/_includes/header.html), rather than adding each page to the menu using page attributes.
 
@@ -180,9 +180,9 @@ The informational pages on this site (e.g., this page, [About](/about), [FAQ](/a
 {% capture accordionContent %}
 This site's [visualizations](../../visualize) are governed by several scripts and queries. See the following `README` files for details:
 
-* [scripts/README.md](https://github.com/LLNL/llnl.github.io/blob/main/_visualize/scripts/README.md): data collection scripts
-* [_visualize/README.md](https://github.com/LLNL/llnl.github.io/blob/main/_visualize/README.md): queries to GitHub's GraphQL API
-* [visualize/README.md](https://github.com/LLNL/llnl.github.io/blob/main/visualize/README.md): data storage
+* [`scripts/README.md`](https://github.com/LLNL/llnl.github.io/blob/main/_visualize/scripts/README.md): data collection scripts
+* [`_visualize/README.md`](https://github.com/LLNL/llnl.github.io/blob/main/_visualize/README.md): queries to GitHub's GraphQL API
+* [`visualize/README.md`](https://github.com/LLNL/llnl.github.io/blob/main/visualize/README.md): data storage
 
 {% endcapture %}
   {% assign accordionContent = accordionContent | markdownify %}
@@ -190,7 +190,7 @@ This site's [visualizations](../../visualize) are governed by several scripts an
 
 {% capture accordionContent %}
 
-### Future Materials Science category
+## Materials Science Category
 
 Add `Materials Science` into the catalog browse by adding this code (alphabetically among the other categories) to `/visualize/github-data/category_info.json`:
 
@@ -211,11 +211,11 @@ Add `Materials Science` into the catalog browse by adding this code (alphabetica
             ]
         },
 
-### Deprecated RADIUSS features
+## RADIUSS Features
 
-April 2022: RADIUSS launched at [github.com/llnl/radiuss](https://github.com/llnl/radiuss). See tasks in [issue 567](https://github.com/LLNL/llnl.github.io/issues/567). If we ever want/need to reinstate RADIUSS browsing, branding, and other features on this site, here's what to do:
+April 2022: RADIUSS launched at [github.com/llnl/radiuss](https://github.com/llnl/radiuss). See tasks in [issue 567](https://github.com/LLNL/llnl.github.io/issues/567). If we ever want/need to reinstate RADIUSS browsing, branding, and other features on *this* site, here's what to do:
 
-* Add `RADIUSS` back into the catalog browse (i.e., to "live" on this website) by adding this code (as lines 154-168) to `/visualize/github-data/category_info.json`:
+* Add `RADIUSS` back into the catalog browse (i.e., to "live" on this website) by replacing the existing code (lines 190–205) in `/visualize/github-data/category_info.json` with this:
 
 ```bash
         "RADIUSS": {
@@ -235,9 +235,9 @@ April 2022: RADIUSS launched at [github.com/llnl/radiuss](https://github.com/lln
         },
 ```
 
-Note that `/project/category_info_radiuss.json` is not currently being used. If it were to be reinstated, it would need its categories updated to match the latest Catalog (e.g., `Docs and Tutorials``).
+Note that `/project/category_info_radiuss.json` is not currently being used. If it were to be reinstated, it would need its categories updated to match the latest Catalog (e.g., `Docs and Tutorials`).
 
-* Comment back in lines 31-38 in `Category.service.js`
+<!--* Comment back in lines 31-38 in `Category.service.js`
 
 ```bash
     this.containsRadiussTopics = function(catTopics, repoTopics) {
@@ -248,23 +248,23 @@ Note that `/project/category_info_radiuss.json` is not currently being used. If 
         }
         return false;
     };
-```
+```-->
 
 * Update link/text on home page
-* Update links/text on Policies & Guidelines page
-* Update links/text on FAQ page
+* Update links/text on [Policies & Guidelines](/about/policies)
+* Update links/text on [FAQ](/about/faq)
 * Update relevant READMEs
 * Update links/text on <https://dev.llnl.gov/radiuss/>
 * Point URL alias <https://radiuss.llnl.gov> back to `/explore/#/RADIUSS` (request this of <webmaster-comp@llnl.gov>)
 
 No changes yet, if ever:
 
-* Policies & Guidelines are currently still on this site: (/about/policies)
-* RADIUSS logo (`radiuss.svg`) is still in the `/assets/` folder
+* [Policies & Guidelines](/about/policies) are currently still on this site
+* RADIUSS logo (`radiuss-icon-bw.png`) is still in the `/assets/images/` folder
 
 {% endcapture %}
   {% assign accordionContent = accordionContent | markdownify %}
-  {% include components/accordion.html title='For site admins only: notes on future and deprecated features' slug='admins' content=accordionContent %}
+  {% include components/accordion.html title='For site admins: notes on deprecated features' slug='admins' content=accordionContent %}
 
 </div>
 <!-- END: Accordions -->

--- a/about/index.md
+++ b/about/index.md
@@ -39,7 +39,7 @@ LLNL is a Department of Energy ([DOE](https://www.energy.gov/national-laboratori
   </div>
 </div>
 
-We often work with other national labs, universities, and industry partners. Working on these projects is a lot easier when we can share code directly. The Exascale Computing Project ([ECP](https://www.exascaleproject.org)) uses OSS to develop the exascale ecosystem of apps, analytics, infrastructure, and so much more. Future breakthroughs will likely owe some debt to the best practices and accelerated development made possible by OSS.
+We often work with other national labs, universities, and industry partners. Working on these projects is a lot easier when we can share code directly. The DOE's Exascale Computing Project ([ECP](https://www.exascaleproject.org)) (2016–2024) used OSS to develop the exascale ecosystem of apps, analytics, infrastructure, and so much more. Future breakthroughs will likely owe some debt to the best practices and accelerated development made possible by OSS.
 
 One of the great things about a large government organization is that we're not motivated by profit. "The greater good" might sound like a cliché, but it's true. LLNL's national security mission governs our work, so our OSS portfolio of apps, libraries, compilers, and other tools support that mission. This includes everything from monitoring the performance of our supercomputers to making multiphysics codes run more smoothly.
 
@@ -68,39 +68,38 @@ This website abounds with examples of projects that have found a home in the ope
 <!-- START: Quicklinks boxes -->
 {% capture cardContent %}
 * [LLNL Software News](/news)
+* [LLNL Computing News](https://computing.llnl.gov/topic/open-source-software)
+* [The Lab that Launched a Thousand Software Projects](https://computing.llnl.gov/about/newsroom/lab-launched-thousand-software-projects)
 * [The Case for Open Source Software](https://18f.gsa.gov/2018/07/12/the-case-for-open-source-software/)
-* [OSS Spotlight: LLNL and ZFS on Linux](https://medium.com/codedotgov/oss-spotlight-lawrence-livermore-national-laboratory-and-zfs-on-linux-6596fca6e5f6)
-* [Spack, A Lab-Developed ‘App Store for Supercomputers,’ becoming Standard-Bearer](https://www.llnl.gov/news/spack-lab-developed-app-store-supercomputers-becoming-standard-bearer)
+* [Ambassadors of Code](https://str.llnl.gov/2018-01/lee)  (*Science & Technology Review* cover story)
 {% endcapture %}
 {% assign cardContent = cardContent | markdownify %}
-{% include components/card.html title='Open Source at LLNL' content=cardContent classes="h-100" %}
-<!-- END: Quicklinks boxes -->
-  </div>
-  <div class="col-12 col-lg-4">
-<!-- START: Quicklinks boxes -->
-{% capture cardTitle %}
-*Science & Technology Review* coverage
-{% endcapture %}
-{% capture cardContent %}
-* [Ambassadors of Code (cover story)](https://str.llnl.gov/2018-01/lee)
-* [Ambassadors of Code (video, 3:04)](https://youtu.be/nTxMn1NWHQU)
-* [Commentary by Bruce Hendrickson](https://str.llnl.gov/2018-01/comjan18)
-* [Visualization Software Stands the Test of Time](https://str.llnl.gov/2021-05/brugger)
-{% endcapture %}
-{% assign cardTitle = cardTitle | markdownify %}
-{% assign cardContent = cardContent | markdownify %}
-{% include components/card.html title=cardTitle content=cardContent classes="h-100" %}
+{% include components/card.html title='News Coverage' content=cardContent classes="h-100" %}
 <!-- END: Quicklinks boxes -->
   </div>
   <div class="col-12 col-lg-4">
 <!-- START: Quicklinks boxes -->
 {% capture cardContent %}
-* [Releasing Open Source Software at the Lab (poster)](https://computing.llnl.gov/sites/default/files/COMP_Poster_OSS.pdf)
-* [Open Source at LLNL (video, 11:31)](https://youtu.be/kL4wIYhNVxE)
-* [Open Source at LLNL (slides)](https://computing.llnl.gov/sites/default/files/2020CompExpo_Open_Source.pdf)
+* [UnifyFS: User-Level File System for Supercomputers](https://computing.llnl.gov/projects/unifyfs)
+* [UMap: An Application-Oriented, User-Level Memory-Mapping Library](https://computing.llnl.gov/projects/umap)
+* [zfp: Compressed Floating-Point and Integer Arrays](https://computing.llnl.gov/projects/zfp)
+* [Variorum: Vendor-Agnostic Power Management](https://computing.llnl.gov/projects/variorum)
+* [The Laboratory’s Habit of Innovation](https://str.llnl.gov/past-issues/march-2024/laboratorys-habit-innovation)  (*Science & Technology Review* cover story)
 {% endcapture %}
 {% assign cardContent = cardContent | markdownify %}
-{% include components/card.html title='LLNL Computing Virtual Expo Materials' content=cardContent classes="h-100" %}
+{% include components/card.html title='R&D 100 Winners (2023–2024)' content=cardContent classes="h-100" %}
+<!-- END: Quicklinks boxes -->
+  </div>
+  <div class="col-12 col-lg-4">
+<!-- START: Quicklinks boxes -->
+{% capture cardContent %}
+* [How Will El Capitan Run? Software and Storage Solutions Powering NNSA’s First Exascale Supercomputer](https://www.youtube.com/watch?v=K7ccgEoJnuM) (5:56)
+* [Supercomputer Problems You’ve Never Heard Of](https://www.youtube.com/watch?v=IZSWymZmkc0) (5:39)
+* [Ambassadors of Code](https://www.youtube.com/watch?v=nTxMn1NWHQU) (3:04)
+* [An Introduction to Open Source Software](https://www.youtube.com/watch?v=kL4wIYhNVxE) (11:31)
+{% endcapture %}
+{% assign cardContent = cardContent | markdownify %}
+{% include components/card.html title='Multimedia' content=cardContent classes="h-100" %}
 <!-- END: Quicklinks boxes -->
   </div>
 </div>

--- a/assets/js/news/news.js
+++ b/assets/js/news/news.js
@@ -41,7 +41,7 @@ module('tid-custom', ['ngAnimate'])
 
 angular.module("app", ['tid-custom']).controller("PostController", function($scope, $sce) {
     $scope.sortByValue = '-date';
-    $scope.lowerBoundYear = 2021;
+    $scope.lowerBoundYear = 2023;
 
     for (var i = 0; i < posts.items.length; i++) {
         var post = posts.items[i],

--- a/assets/js/news/release.js
+++ b/assets/js/news/release.js
@@ -5,7 +5,7 @@ angular.module("app", ['ngAnimate']).controller("ReleaseController", function($s
     $scope.releases = [];
     $scope.activeYear = null;
 
-    $scope.lowerBoundYear = 2021;
+    $scope.lowerBoundYear = 2023;
     
     $scope.filterByPublishedAt = function(value, index, array) {
       return !$scope.activeYear || ($scope.activeYear && value.publishedAt.value.getFullYear() == $scope.activeYear);

--- a/news/index.md
+++ b/news/index.md
@@ -1,7 +1,7 @@
 ---
 title: News
 layout: default
-description: Get answers to frequently asked questions about Lawrence Livermore National Laboratory's open source software.
+description: Get answers to frequently asked questions about LLNL's open source software.
 permalink: /news/
 breadcrumb: News
 ---


### PR DESCRIPTION
- The About page resources were mostly outdated; changed the "card" content and titles
- News and Releases were showing 2021-2022 content; updated to 2023 as lower bound year
- Some edits to headings, links, etc. throughout